### PR TITLE
Introduce benchmark on fast matrix product

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ list(APPEND SOURCE_FILES
     ${SOFABENCHMARK_SRC}/benchmarks/SofaCore/NarrowPhaseDetection.cpp
     ${SOFABENCHMARK_SRC}/benchmarks/SofaHelper/AdvancedTimer.cpp
     ${SOFABENCHMARK_SRC}/benchmarks/SofaHelper/MapPtrStableCompare.cpp
+    ${SOFABENCHMARK_SRC}/benchmarks/Sofa.LinearAlgebra/SparseMatrixProduct.cpp
 )
 
 

--- a/src/benchmarks/Sofa.LinearAlgebra/SparseMatrixProduct.cpp
+++ b/src/benchmarks/Sofa.LinearAlgebra/SparseMatrixProduct.cpp
@@ -1,0 +1,156 @@
+﻿#include <iostream>
+#include <benchmark/benchmark.h>
+
+#include <sofa/linearalgebra/SparseMatrixProduct[EigenSparseMatrix].h>
+
+#include <sofa/helper/random.h>
+
+/// Sparsity is a ratio between 0 and 1
+template <typename TReal = SReal>
+static void generateRandomSparseMatrix(Eigen::SparseMatrix<TReal>& eigenMatrix, Eigen::Index nbRows, Eigen::Index nbCols, TReal sparsity)
+{
+    eigenMatrix.resize(nbRows, nbCols);
+    sofa::type::vector<Eigen::Triplet<TReal> > triplets;
+
+    const auto nbNonZero = static_cast<Eigen::Index>(sparsity * static_cast<TReal>(nbRows*nbCols));
+
+    for (Eigen::Index i = 0; i < nbNonZero; ++i)
+    {
+        const auto value = static_cast<TReal>(sofa::helper::drand(1));
+        const auto row = static_cast<Eigen::Index>(sofa::helper::drandpos(nbRows) - 1e-8);
+        const auto col = static_cast<Eigen::Index>(sofa::helper::drandpos(nbCols) - 1e-8);
+        triplets.emplace_back(row, col, value);
+    }
+
+    eigenMatrix.setFromTriplets(triplets.begin(), triplets.end());
+}
+
+template<class TMatrix>
+class BM_SparseMatrixProduct : public benchmark::Fixture
+{
+public:
+
+    void SetUp(const ::benchmark::State& state) override
+    {
+        const auto matrixSize = state.range(0);
+        const auto sparsityPerMil = state.range(1);
+        const auto sparsity = static_cast<SReal>(sparsityPerMil) / 1000.; //since only integers can be passed as an argument, a number between 0 and 1000 must be provided
+
+        auto itA = matrixMapA.find({matrixSize, sparsityPerMil});
+        if (itA == matrixMapA.end())
+        {
+            TMatrix matrixA;
+            generateRandomSparseMatrix(matrixA, matrixSize, matrixSize, sparsity);
+            if (const auto insertIt = matrixMapA.insert({{matrixSize, sparsityPerMil}, matrixA}); insertIt.second)
+            {
+                a = &insertIt.first->second;
+            }
+        }
+        else
+        {
+            a = &itA->second;
+        }
+
+        auto itB = matrixMapB.find({matrixSize, sparsityPerMil});
+        if (itB == matrixMapB.end())
+        {
+            TMatrix matrixB;
+            generateRandomSparseMatrix(matrixB, matrixSize, matrixSize, sparsity);
+            if (const auto insertIt = matrixMapB.insert({ {matrixSize, sparsityPerMil}, matrixB}); insertIt.second)
+            {
+                b = &insertIt.first->second;
+            }
+        }
+        else
+        {
+            b = &itB->second;
+        }
+
+        auto it = productMap.find({matrixSize, sparsityPerMil});
+        if (it == productMap.end())
+        {
+            sofa::linearalgebra::SparseMatrixProduct<TMatrix> p;
+            const auto insertIt = productMap.insert({ {matrixSize, sparsityPerMil}, p});
+            if (insertIt.second)
+            {
+                product = &insertIt.first->second;
+
+                product->matrixA = a;
+                product->matrixB = b;
+                product->computeProduct();
+            }
+        }
+        else
+        {
+            product = &it->second;
+        }
+
+    }
+
+    void regularProduct(benchmark::State& state)
+    {
+        product->computeRegularProduct();
+    }
+
+    void fastProduct(benchmark::State& state)
+    {
+        product->computeProduct();
+    }
+
+    void forceComputingIntersection(benchmark::State& state)
+    {
+        product->computeProduct(true);
+    }
+
+    sofa::linearalgebra::SparseMatrixProduct<TMatrix>* product { nullptr };
+
+private:
+
+    TMatrix* a { nullptr };
+    TMatrix* b { nullptr };
+
+    static std::map< std::pair< int, int>, TMatrix> matrixMapA, matrixMapB;
+    static std::map< std::pair< int, int>, sofa::linearalgebra::SparseMatrixProduct<TMatrix> > productMap;
+};
+
+template<class TMatrix>
+std::map< std::pair< int, int>, TMatrix> BM_SparseMatrixProduct<TMatrix>::matrixMapA;
+template<class TMatrix>
+std::map< std::pair< int, int>, TMatrix> BM_SparseMatrixProduct<TMatrix>::matrixMapB;
+template<class TMatrix>
+std::map< std::pair< int, int>, sofa::linearalgebra::SparseMatrixProduct<TMatrix> > BM_SparseMatrixProduct<TMatrix>::productMap;
+
+BENCHMARK_TEMPLATE_DEFINE_F(BM_SparseMatrixProduct, RegularProduct, Eigen::SparseMatrix<SReal>)(benchmark::State& st)
+{
+    for (auto _ : st)
+    {
+        this->regularProduct(st);
+    }
+}
+BENCHMARK_REGISTER_F(BM_SparseMatrixProduct, RegularProduct)->Unit(benchmark::kMicrosecond)
+    ->ArgsProduct({{100, 1000}, {10, 20, 100, 150}})
+    ->Args({10000, 1})
+    ->Args({10000, 5});
+
+BENCHMARK_TEMPLATE_DEFINE_F(BM_SparseMatrixProduct, FastProduct, Eigen::SparseMatrix<SReal>)(benchmark::State& st)
+{
+    for (auto _ : st)
+    {
+        this->fastProduct(st);
+    }
+}
+BENCHMARK_REGISTER_F(BM_SparseMatrixProduct, FastProduct)->Unit(benchmark::kMicrosecond)
+    ->ArgsProduct({{100, 1000}, {10, 20, 100, 150}})
+    ->Args({10000, 1})
+    ->Args({10000, 5});
+
+
+BENCHMARK_TEMPLATE_DEFINE_F(BM_SparseMatrixProduct, ForceComputingIntersection, Eigen::SparseMatrix<SReal>)(benchmark::State& st)
+{
+    for (auto _ : st)
+    {
+        this->forceComputingIntersection(st);
+    }
+}
+// BENCHMARK_REGISTER_F(BM_SparseMatrixProduct, ForceComputingIntersection)->Unit(benchmark::kMicrosecond)
+//     ->ArgsProduct({{100, 1000},{10}});

--- a/src/benchmarks/SofaBaseLinearSolver/CompressedRowSparse.cpp
+++ b/src/benchmarks/SofaBaseLinearSolver/CompressedRowSparse.cpp
@@ -10,12 +10,12 @@ class BM_CRS_Fixture : public benchmark::Fixture
 {
 public:
     /// Setup a matrix of size 3000x3000
-    void SetUp(const ::benchmark::State& state)
+    void SetUp(const ::benchmark::State& state) override
     {
         mat.resize(3 * 1000, 3 * 1000);
     }
 
-    void TearDown(const ::benchmark::State& state)
+    void TearDown(const ::benchmark::State& state) override
     {
         mat.clear();
     }


### PR DESCRIPTION
Fast sparse matrix product is introduced in https://github.com/sofa-framework/sofa/pull/2394.
The added benchmarks allow to compare the speedup from a regular sparse matrix product.

In the benchmarks, the size of the matrix and the sparsity (ratio of non-zero entries compared to the size of the matrix) vary.
Here are the results on my computer:
```
---------------------------------------------------------------------------------------------------------------------
Benchmark                                                                           Time             CPU   Iterations
---------------------------------------------------------------------------------------------------------------------
BM_SparseMatrixProduct<Eigen::SparseMatrix<SReal>>/RegularProduct/100/10         1.88 us         1.88 us       373333
BM_SparseMatrixProduct<Eigen::SparseMatrix<SReal>>/RegularProduct/1000/10        1884 us         1885 us          373
BM_SparseMatrixProduct<Eigen::SparseMatrix<SReal>>/RegularProduct/100/20         3.44 us         3.45 us       194783
BM_SparseMatrixProduct<Eigen::SparseMatrix<SReal>>/RegularProduct/1000/20        6321 us         6417 us          112
BM_SparseMatrixProduct<Eigen::SparseMatrix<SReal>>/RegularProduct/100/100        50.6 us         51.6 us        10000
BM_SparseMatrixProduct<Eigen::SparseMatrix<SReal>>/RegularProduct/1000/100      29409 us        29297 us           24
BM_SparseMatrixProduct<Eigen::SparseMatrix<SReal>>/RegularProduct/100/150        96.6 us         96.3 us         7467
BM_SparseMatrixProduct<Eigen::SparseMatrix<SReal>>/RegularProduct/1000/150      34765 us        35156 us           20
BM_SparseMatrixProduct<Eigen::SparseMatrix<SReal>>/RegularProduct/10000/1       22925 us        22917 us           30
BM_SparseMatrixProduct<Eigen::SparseMatrix<SReal>>/RegularProduct/10000/5      776510 us       765625 us            1
BM_SparseMatrixProduct<Eigen::SparseMatrix<SReal>>/FastProduct/100/10           0.169 us        0.171 us      4480000
BM_SparseMatrixProduct<Eigen::SparseMatrix<SReal>>/FastProduct/1000/10            226 us          225 us         2987
BM_SparseMatrixProduct<Eigen::SparseMatrix<SReal>>/FastProduct/100/20           0.667 us        0.663 us       896000
BM_SparseMatrixProduct<Eigen::SparseMatrix<SReal>>/FastProduct/1000/20           1410 us         1412 us          498
BM_SparseMatrixProduct<Eigen::SparseMatrix<SReal>>/FastProduct/100/100           17.8 us         17.6 us        37333
BM_SparseMatrixProduct<Eigen::SparseMatrix<SReal>>/FastProduct/1000/100         30018 us        29948 us           24
BM_SparseMatrixProduct<Eigen::SparseMatrix<SReal>>/FastProduct/100/150           44.8 us         44.5 us        15448
BM_SparseMatrixProduct<Eigen::SparseMatrix<SReal>>/FastProduct/1000/150         61459 us        62500 us           11
BM_SparseMatrixProduct<Eigen::SparseMatrix<SReal>>/FastProduct/10000/1           5030 us         5156 us          100
BM_SparseMatrixProduct<Eigen::SparseMatrix<SReal>>/FastProduct/10000/5         136598 us       137500 us            5

```

In a table, it gives (durations are in micro-seconds):
![image](https://user-images.githubusercontent.com/10572752/136766426-a5050d66-59d9-4494-a704-478a703cc44e.png)

The cells in green are when the "fast matrix product" is faster than the regular product. In orange, when it's slower. We can observe, that it starts to become slower when the sparsity ratio increases, and this threshold becomes smaller when the matrix size increases. It makes me think that the key factor for a speed up is the size of the intersection.

