### PR TITLE
Add benchmarks to compare assignment and clear

### DIFF
--- a/src/benchmarks/Sofa.Type/fixed_array.cpp
+++ b/src/benchmarks/Sofa.Type/fixed_array.cpp
@@ -8,6 +8,12 @@
 template <typename Container>
 static void BM_FixedArray_construct(benchmark::State& state);
 
+template <typename Container>
+static void BM_FixedArray_constantAssignment(benchmark::State& state);
+
+template <typename Container>
+static void BM_FixedArray_clear(benchmark::State& state);
+
 using stdarray3f = std::array<float, 3>;
 using sofatypefixedarray3f = sofa::type::fixed_array<float, 3>;
 
@@ -17,6 +23,12 @@ constexpr int64_t maxSubIterations = 8 << 10;
 BENCHMARK_TEMPLATE1(BM_FixedArray_construct, stdarray3f)->RangeMultiplier(2)->Ranges({ {minSubIterations, maxSubIterations} })->Unit(benchmark::kMicrosecond);
 BENCHMARK_TEMPLATE1(BM_FixedArray_construct, sofatypefixedarray3f)->RangeMultiplier(2)->Ranges({ {minSubIterations, maxSubIterations} })->Unit(benchmark::kMicrosecond);
 BENCHMARK_TEMPLATE1(BM_FixedArray_construct, sofa::type::Vec3f)->RangeMultiplier(2)->Ranges({ {minSubIterations, maxSubIterations} })->Unit(benchmark::kMicrosecond);
+
+BENCHMARK_TEMPLATE1(BM_FixedArray_constantAssignment, stdarray3f)->RangeMultiplier(2)->Ranges({ {minSubIterations, maxSubIterations} });
+BENCHMARK_TEMPLATE1(BM_FixedArray_constantAssignment, sofatypefixedarray3f)->RangeMultiplier(2)->Ranges({ {minSubIterations, maxSubIterations} });
+BENCHMARK_TEMPLATE1(BM_FixedArray_constantAssignment, sofa::type::Vec3f)->RangeMultiplier(2)->Ranges({ {minSubIterations, maxSubIterations} });
+
+BENCHMARK_TEMPLATE1(BM_FixedArray_clear, sofa::type::Vec3f)->RangeMultiplier(2)->Ranges({ {minSubIterations, maxSubIterations} });
 
 template <typename Container>
 void BM_FixedArray_construct(benchmark::State& state)
@@ -29,6 +41,32 @@ void BM_FixedArray_construct(benchmark::State& state)
         for (unsigned int i = 0; i < state.range(0); ++i)
         {
             benchmark::DoNotOptimize(Container{values[i], values[i+1], values[i+2]});
+        }
+    }
+}
+
+template <typename Container>
+void BM_FixedArray_constantAssignment(benchmark::State& state)
+{
+    Container c;
+    for (auto _ : state)
+    {
+        for (unsigned int i = 0; i < state.range(0); ++i)
+        {
+            benchmark::DoNotOptimize(c = Container());
+        }
+    }
+}
+
+template <typename Container>
+void BM_FixedArray_clear(benchmark::State& state)
+{
+    Container c;
+    for (auto _ : state)
+    {
+        for (unsigned int i = 0; i < state.range(0); ++i)
+        {
+            c.clear();
         }
     }
 }


### PR DESCRIPTION
New benchmarks to confirm https://github.com/sofa-framework/sofa/pull/2518

```
------------------------------------------------------------------------------------------------------
Benchmark                                                            Time             CPU   Iterations
------------------------------------------------------------------------------------------------------
BM_FixedArray_constantAssignment<stdarray3f>/2048                 2240 ns         2246 ns       320000
BM_FixedArray_constantAssignment<stdarray3f>/4096                 4455 ns         4499 ns       149333
BM_FixedArray_constantAssignment<stdarray3f>/8192                 8937 ns         8789 ns        74667
BM_FixedArray_constantAssignment<sofatypefixedarray3f>/2048       4449 ns         4450 ns       154483
BM_FixedArray_constantAssignment<sofatypefixedarray3f>/4096       8876 ns         8789 ns        74667
BM_FixedArray_constantAssignment<sofatypefixedarray3f>/8192      17949 ns        18032 ns        40727
BM_FixedArray_constantAssignment<sofa::type::Vec3f>/2048         11199 ns        11230 ns        64000
BM_FixedArray_constantAssignment<sofa::type::Vec3f>/4096         22322 ns        22321 ns        28000
BM_FixedArray_constantAssignment<sofa::type::Vec3f>/8192         44708 ns        44922 ns        16000


--------------------------------------------------------------------------------------
Benchmark                                            Time             CPU   Iterations
--------------------------------------------------------------------------------------
BM_FixedArray_clear<sofa::type::Vec3f>/2048       2285 ns         2250 ns       298667
BM_FixedArray_clear<sofa::type::Vec3f>/4096       4638 ns         4653 ns       154483
BM_FixedArray_clear<sofa::type::Vec3f>/8192       9199 ns         9208 ns        74667

```