### PR TITLE
Pause timing for init for consistent measures

### DIFF
--- a/SofaBenchmarkScenes/src/SofaBenchmarkScenes/BenchScene.h
+++ b/SofaBenchmarkScenes/src/SofaBenchmarkScenes/BenchScene.h
@@ -29,6 +29,8 @@ void BM_Scene_bench_SimulationFactor(benchmark::State& state)
     {
         for (auto i = 0; i < state.range(0); ++i)
         {
+            state.PauseTiming();
+
             // Not ideal but did not find a way to clone/duplicate a scene
             sofa::simulation::Node::SPtr root = TScene::getRoot();
             root->init(sofa::core::execparams::defaultInstance());


### PR DESCRIPTION


```
------------------------------------------------------------------------------------------------------------------------
Benchmark                                                              Time             CPU   Iterations UserCounters...
------------------------------------------------------------------------------------------------------------------------
BM_Scene_bench_SimulationFactor<SimpleScene>/8                      81.0 ms         71.4 ms            7 FPS=112k/s frame=8.92857us
BM_Scene_bench_SimulationFactor<SimpleScene>/16                      158 ms          148 ms            4 FPS=107.789k/s frame=9.27734us
BM_Scene_bench_SimulationFactor<SimpleScene>/32                      311 ms          312 ms            2 FPS=102.4k/s frame=9.76562us
BM_Scene_bench_SimulationFactor<SimpleScene>/64                      631 ms          656 ms            1 FPS=97.5238k/s frame=10.2539us
BM_Scene_bench_SimulationFactor<SimpleScene>/128                    1252 ms         1219 ms            1 FPS=105.026k/s frame=9.52148us
BM_Scene_bench_StepFactor<SimpleScene>/512                          2.50 ms         2.68 ms          280 FPS=191.147k/s frame=5.23158us
BM_Scene_bench_StepFactor<SimpleScene>/1024                         5.05 ms         5.47 ms          100 FPS=187.246k/s frame=5.34058us
BM_Scene_bench_StepFactor<SimpleScene>/2048                         10.5 ms         10.6 ms           56 FPS=193.159k/s frame=5.17709us
BM_Scene_bench_StepFactor<SimpleScene>/4096                         20.7 ms         20.1 ms           28 FPS=203.89k/s frame=4.90461us
BM_Scene_bench_SimulationFactor<DiagonalMassScene>/2               13503 ms        13469 ms            1 FPS=148.492/s frame=6.73438ms
BM_Scene_bench_SimulationFactor<DiagonalMassScene>/4               26548 ms        26562 ms            1 FPS=150.588/s frame=6.64062ms
BM_Scene_bench_SimulationFactor<DiagonalMassScene>/8               53424 ms        53438 ms            1 FPS=149.708/s frame=6.67969ms
BM_Scene_bench_SimulationFactor<DiagonalMassScene>/16             106631 ms       106531 ms            1 FPS=150.191/s frame=6.6582ms
BM_Scene_bench_SimulationFactor<DiagonalMassScene>/32             214378 ms       214281 ms            1 FPS=149.336/s frame=6.69629ms
BM_Scene_bench_StepFactor<DiagonalMassScene>/512                    4639 ms         4656 ms            1 FPS=109.96/s frame=9.09424ms
BM_Scene_bench_StepFactor<DiagonalMassScene>/1024                   9071 ms         9062 ms            1 FPS=112.993/s frame=8.8501ms
BM_Scene_bench_StepFactor<DiagonalMassScene>/2048                  16516 ms        16469 ms            1 FPS=124.357/s frame=8.04138ms
BM_Scene_bench_StepFactor<DiagonalMassScene>/4096                  25450 ms        25344 ms            1 FPS=161.618/s frame=6.18744ms
BM_Scene_bench_SimulationFactor<MeshMatrixMassScene>/2             15218 ms        15250 ms            1 FPS=131.148/s frame=7.625ms
BM_Scene_bench_SimulationFactor<MeshMatrixMassScene>/4             30164 ms        30156 ms            1 FPS=132.642/s frame=7.53906ms
BM_Scene_bench_SimulationFactor<MeshMatrixMassScene>/8             59796 ms        59531 ms            1 FPS=134.383/s frame=7.44141ms
BM_Scene_bench_SimulationFactor<MeshMatrixMassScene>/16           123321 ms       122906 ms            1 FPS=130.181/s frame=7.68164ms
BM_Scene_bench_SimulationFactor<MeshMatrixMassScene>/32           243603 ms       243328 ms            1 FPS=131.51/s frame=7.604ms
BM_Scene_bench_StepFactor<MeshMatrixMassScene>/512                  3975 ms         3938 ms            1 FPS=130.032/s frame=7.69043ms
BM_Scene_bench_StepFactor<MeshMatrixMassScene>/1024                 7757 ms         7750 ms            1 FPS=132.129/s frame=7.56836ms
BM_Scene_bench_StepFactor<MeshMatrixMassScene>/2048                13993 ms        13938 ms            1 FPS=146.942/s frame=6.80542ms
BM_Scene_bench_StepFactor<MeshMatrixMassScene>/4096                25125 ms        25094 ms            1 FPS=163.228/s frame=6.1264ms
BM_Scene_bench_StepFactor<TetrahedronFEMForceFieldScene>/512        3531 ms         3531 ms            1 FPS=144.991/s frame=6.89697ms
BM_Scene_bench_StepFactor<TetrahedronFEMForceFieldScene>/1024       6962 ms         6969 ms            1 FPS=146.942/s frame=6.80542ms
BM_Scene_bench_StepFactor<TetrahedronFEMForceFieldScene>/2048      13790 ms        13781 ms            1 FPS=148.608/s frame=6.72913ms
BM_Scene_bench_StepFactor<TetrahedronFEMForceFieldScene>/4096      28828 ms        28781 ms            1 FPS=142.315/s frame=7.02667ms
```