### PR TITLE
Benchmark the task scheduler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,18 +29,20 @@ set(SOURCE_FILES ${SOFABENCHMARK_SRC}/Main.cpp)
 list(APPEND HEADER_FILES
     ${SOFABENCHMARK_SRC}/benchmarks/SofaCore/NarrowPhaseDetection.h
     ${SOFABENCHMARK_SRC}/utils/RandomValuePool.h
+    ${SOFABENCHMARK_SRC}/utils/thread_pool.hpp
 )
 list(APPEND SOURCE_FILES
+    ${SOFABENCHMARK_SRC}/benchmarks/Sofa.LinearAlgebra/SparseMatrixProduct.cpp
+    ${SOFABENCHMARK_SRC}/benchmarks/Sofa.Type/Matrix.cpp
+    ${SOFABENCHMARK_SRC}/benchmarks/Sofa.Type/Vec.cpp
+    ${SOFABENCHMARK_SRC}/benchmarks/Sofa.Type/fixed_array.cpp
     ${SOFABENCHMARK_SRC}/benchmarks/SofaBaseLinearSolver/CompressedRowSparse.cpp
     ${SOFABENCHMARK_SRC}/benchmarks/SofaCore/MultiVecId.cpp
     ${SOFABENCHMARK_SRC}/benchmarks/SofaCore/NarrowPhaseDetection.cpp
     ${SOFABENCHMARK_SRC}/benchmarks/SofaCore/ReadAccessor.cpp
     ${SOFABENCHMARK_SRC}/benchmarks/SofaHelper/AdvancedTimer.cpp
     ${SOFABENCHMARK_SRC}/benchmarks/SofaHelper/MapPtrStableCompare.cpp
-    ${SOFABENCHMARK_SRC}/benchmarks/Sofa.LinearAlgebra/SparseMatrixProduct.cpp
-    ${SOFABENCHMARK_SRC}/benchmarks/Sofa.Type/fixed_array.cpp
-    ${SOFABENCHMARK_SRC}/benchmarks/Sofa.Type/Vec.cpp
-    ${SOFABENCHMARK_SRC}/benchmarks/Sofa.Type/Matrix.cpp
+    ${SOFABENCHMARK_SRC}/benchmarks/SofaSimulationCore/TaskScheduler.cpp
 )
 
 option(SOFABENCHMARK_BUILD_BENCH_SCENES "Add benchmarking SOFA scenes." ON)

--- a/src/benchmarks/SofaSimulationCore/TaskScheduler.cpp
+++ b/src/benchmarks/SofaSimulationCore/TaskScheduler.cpp
@@ -1,0 +1,167 @@
+#include <benchmark/benchmark.h>
+#include <sofa/simulation/DefaultTaskScheduler.h>
+#include <sofa/simulation/CpuTask.h>
+#include <sofa/type/vector_T.h>
+
+#include <utils/thread_pool.hpp>
+
+constexpr unsigned int payloadDurationMicroseconds = 100;
+const auto taskNumberRange = benchmark::CreateRange(1e3, 1e5, 10);
+const auto threadNumberRange = benchmark::CreateRange(1, std::thread::hardware_concurrency(), 2);
+
+class EmptyTask : public sofa::simulation::CpuTask
+{
+public:
+    explicit EmptyTask(sofa::simulation::CpuTask::Status* status)
+        : sofa::simulation::CpuTask(status) {}
+
+    sofa::simulation::Task::MemoryAlloc run() final
+    {
+        return sofa::simulation::Task::Stack;
+    }
+};
+
+constexpr auto payloadTask = []()
+{
+    const auto begin = std::chrono::high_resolution_clock::now();
+    long long newId = 0;
+    while ( std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now() - begin).count() < payloadDurationMicroseconds)
+    {
+        for (int i = 1; i < begin.time_since_epoch().count() % 100; ++i)
+        {
+            newId += begin.time_since_epoch().count() / i;
+            newId %= begin.time_since_epoch().count();
+        }
+    }
+};
+
+class PayloadTask : public sofa::simulation::CpuTask
+{
+public:
+    explicit PayloadTask(sofa::simulation::CpuTask::Status* status)
+        : sofa::simulation::CpuTask(status) {}
+
+    sofa::simulation::Task::MemoryAlloc run() final
+    {
+        payloadTask();
+        return sofa::simulation::Task::Stack;
+    }
+};
+
+
+template<class TTask>
+static void BM_TaskScheduler(benchmark::State &state)
+{
+    auto *taskScheduler = sofa::simulation::TaskScheduler::getInstance();
+    assert(taskScheduler != nullptr);
+
+    taskScheduler->init(state.range(1));
+
+    for (auto _ : state)
+    {
+        state.PauseTiming();
+
+        sofa::type::vector<TTask> tasks;
+        tasks.reserve(state.range(0));
+
+        sofa::simulation::CpuTask::Status status;
+
+        state.ResumeTiming();
+
+        for (unsigned int i = 0; i < state.range(0); ++i)
+        {
+            tasks.emplace_back(&status);
+            taskScheduler->addTask(&tasks.back());
+        }
+
+        taskScheduler->workUntilDone(&status);
+    }
+
+    if constexpr (std::is_same_v<TTask, PayloadTask>)
+    {
+        //The duration in ms that it would take if no overhead: number of tasks * duration of one task / nb of threads
+        state.counters["theoryMs"] = benchmark::Counter(state.range(0) * payloadDurationMicroseconds / 1000 / sofa::simulation::TaskScheduler::getInstance()->getThreadCount());
+    }
+}
+
+BENCHMARK_TEMPLATE(BM_TaskScheduler, EmptyTask)->ArgsProduct(
+{
+    taskNumberRange, threadNumberRange
+})->Threads(1)->Unit(benchmark::kMillisecond);
+BENCHMARK_TEMPLATE(BM_TaskScheduler, PayloadTask)->ArgsProduct(
+{
+    taskNumberRange, threadNumberRange
+})->Threads(1)->Unit(benchmark::kMillisecond);
+
+static void BM_ThreadPool_EmptyTasks(benchmark::State &state)
+{
+    constexpr auto emptyTask = [](){};
+    for (auto _ : state)
+    {
+        state.PauseTiming();
+        thread_pool pool(state.range(1));
+        state.ResumeTiming();
+
+        for (unsigned int i = 0; i < state.range(0); ++i)
+        {
+            pool.push_task(emptyTask);
+        }
+        pool.wait_for_tasks();
+    }
+}
+
+static void BM_ThreadPool_PayloadTask(benchmark::State &state)
+{
+    for (auto _ : state)
+    {
+        state.PauseTiming();
+        thread_pool pool(state.range(1));
+        state.ResumeTiming();
+
+        for (unsigned int i = 0; i < state.range(0); ++i)
+        {
+            pool.push_task(payloadTask);
+        }
+        pool.wait_for_tasks();
+    }
+
+    //The duration in ms that it would take if no overhead: number of tasks * duration of one task / nb of threads
+    state.counters["theoryMs"] = benchmark::Counter(state.range(0) * payloadDurationMicroseconds / 1000 / state.range(1));
+}
+
+static void BM_ThreadPool_PayloadTask_ParallelizeLoop(benchmark::State &state)
+{
+    constexpr auto loop = [](const unsigned int a, const unsigned int b)
+    {
+        for (unsigned int i = a; i < b; i++)
+        {
+            payloadTask();
+        }
+    };
+    for (auto _ : state)
+    {
+        state.PauseTiming();
+        thread_pool pool(state.range(1));
+        state.ResumeTiming();
+
+        pool.parallelize_loop(0, state.range(0), loop);
+
+        pool.wait_for_tasks();
+    }
+
+    //The duration in ms that it would take if no overhead: number of tasks * duration of one task / nb of threads
+    state.counters["theoryMs"] = benchmark::Counter(state.range(0) * payloadDurationMicroseconds / 1000 / state.range(1));
+}
+
+BENCHMARK(BM_ThreadPool_EmptyTasks)->ArgsProduct(
+{
+    taskNumberRange, threadNumberRange
+})->Threads(1)->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_ThreadPool_PayloadTask)->ArgsProduct(
+{
+    taskNumberRange,threadNumberRange
+})->Threads(1)->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_ThreadPool_PayloadTask_ParallelizeLoop)->ArgsProduct(
+{
+    taskNumberRange,threadNumberRange
+})->Threads(1)->Unit(benchmark::kMillisecond);

--- a/src/utils/thread_pool.hpp
+++ b/src/utils/thread_pool.hpp
@@ -1,0 +1,544 @@
+#pragma once
+
+/**
+ * @file thread_pool.hpp
+ * @author Barak Shoshany (baraksh@gmail.com) (http://baraksh.com)
+ * @version 2.0.0
+ * @date 2021-08-14
+ * @copyright Copyright (c) 2021 Barak Shoshany. Licensed under the MIT license. If you use this library in published research, please cite it as follows:
+ *  - Barak Shoshany, "A C++17 Thread Pool for High-Performance Scientific Computing", doi:10.5281/zenodo.4742687, arXiv:2105.00613 (May 2021)
+ *
+ * @brief A C++17 thread pool for high-performance scientific computing.
+ * @details A modern C++17-compatible thread pool implementation, built from scratch with high-performance scientific computing in mind. The thread pool is implemented as a single lightweight and self-contained class, and does not have any dependencies other than the C++17 standard library, thus allowing a great degree of portability. In particular, this implementation does not utilize OpenMP or any other high-level multithreading APIs, and thus gives the programmer precise low-level control over the details of the parallelization, which permits more robust optimizations. The thread pool was extensively tested on both AMD and Intel CPUs with up to 40 cores and 80 threads. Other features include automatic generation of futures and easy parallelization of loops. Two helper classes enable synchronizing printing to an output stream by different threads and measuring execution time for benchmarking purposes. Please visit the GitHub repository at https://github.com/bshoshany/thread-pool for documentation and updates, or to submit feature requests and bug reports.
+ */
+
+#define THREAD_POOL_VERSION "v2.0.0 (2021-08-14)"
+
+#include <atomic>      // std::atomic
+#include <chrono>      // std::chrono
+#include <cstdint>     // std::int_fast64_t, std::uint_fast32_t
+#include <functional>  // std::function
+#include <future>      // std::future, std::promise
+#include <iostream>    // std::cout, std::ostream
+#include <memory>      // std::shared_ptr, std::unique_ptr
+#include <mutex>       // std::mutex, std::scoped_lock
+#include <queue>       // std::queue
+#include <thread>      // std::this_thread, std::thread
+#include <type_traits> // std::common_type_t, std::decay_t, std::enable_if_t, std::is_void_v, std::invoke_result_t
+#include <utility>     // std::move
+
+// ============================================================================================= //
+//                                    Begin class thread_pool                                    //
+
+/**
+ * @brief A C++17 thread pool class. The user submits tasks to be executed into a queue. Whenever a thread becomes available, it pops a task from the queue and executes it. Each task is automatically assigned a future, which can be used to wait for the task to finish executing and/or obtain its eventual return value.
+ */
+class thread_pool
+{
+    typedef std::uint_fast32_t ui32;
+    typedef std::uint_fast64_t ui64;
+
+public:
+    // ============================
+    // Constructors and destructors
+    // ============================
+
+    /**
+     * @brief Construct a new thread pool.
+     *
+     * @param _thread_count The number of threads to use. The default value is the total number of hardware threads available, as reported by the implementation. With a hyperthreaded CPU, this will be twice the number of CPU cores. If the argument is zero, the default value will be used instead.
+     */
+    thread_pool(const ui32 &_thread_count = std::thread::hardware_concurrency())
+        : thread_count(_thread_count ? _thread_count : std::thread::hardware_concurrency()), threads(new std::thread[_thread_count ? _thread_count : std::thread::hardware_concurrency()])
+    {
+        create_threads();
+    }
+
+    /**
+     * @brief Destruct the thread pool. Waits for all tasks to complete, then destroys all threads. Note that if the variable paused is set to true, then any tasks still in the queue will never be executed.
+     */
+    ~thread_pool()
+    {
+        wait_for_tasks();
+        running = false;
+        destroy_threads();
+    }
+
+    // =======================
+    // Public member functions
+    // =======================
+
+    /**
+     * @brief Get the number of tasks currently waiting in the queue to be executed by the threads.
+     *
+     * @return The number of queued tasks.
+     */
+    ui64 get_tasks_queued() const
+    {
+        const std::scoped_lock lock(queue_mutex);
+        return tasks.size();
+    }
+
+    /**
+     * @brief Get the number of tasks currently being executed by the threads.
+     *
+     * @return The number of running tasks.
+     */
+    ui32 get_tasks_running() const
+    {
+        return tasks_total - (ui32)get_tasks_queued();
+    }
+
+    /**
+     * @brief Get the total number of unfinished tasks - either still in the queue, or running in a thread.
+     *
+     * @return The total number of tasks.
+     */
+    ui32 get_tasks_total() const
+    {
+        return tasks_total;
+    }
+
+    /**
+     * @brief Get the number of threads in the pool.
+     *
+     * @return The number of threads.
+     */
+    ui32 get_thread_count() const
+    {
+        return thread_count;
+    }
+
+    /**
+     * @brief Parallelize a loop by splitting it into blocks, submitting each block separately to the thread pool, and waiting for all blocks to finish executing. The user supplies a loop function, which will be called once per block and should iterate over the block's range.
+     *
+     * @tparam T1 The type of the first index in the loop. Should be a signed or unsigned integer.
+     * @tparam T2 The type of the index after the last index in the loop. Should be a signed or unsigned integer. If T1 is not the same as T2, a common type will be automatically inferred.
+     * @tparam F The type of the function to loop through.
+     * @param first_index The first index in the loop.
+     * @param index_after_last The index after the last index in the loop. The loop will iterate from first_index to (index_after_last - 1) inclusive. In other words, it will be equivalent to "for (T i = first_index; i < index_after_last; i++)". Note that if first_index == index_after_last, the function will terminate without doing anything.
+     * @param loop The function to loop through. Will be called once per block. Should take exactly two arguments: the first index in the block and the index after the last index in the block. loop(start, end) should typically involve a loop of the form "for (T i = start; i < end; i++)".
+     * @param num_blocks The maximum number of blocks to split the loop into. The default is to use the number of threads in the pool.
+     */
+    template <typename T1, typename T2, typename F>
+    void parallelize_loop(const T1 &first_index, const T2 &index_after_last, const F &loop, ui32 num_blocks = 0)
+    {
+        typedef std::common_type_t<T1, T2> T;
+        T the_first_index = (T)first_index;
+        T last_index = (T)index_after_last;
+        if (the_first_index == last_index)
+            return;
+        if (last_index < the_first_index)
+        {
+            T temp = last_index;
+            last_index = the_first_index;
+            the_first_index = temp;
+        }
+        last_index--;
+        if (num_blocks == 0)
+            num_blocks = thread_count;
+        ui64 total_size = (ui64)(last_index - the_first_index + 1);
+        ui64 block_size = (ui64)(total_size / num_blocks);
+        if (block_size == 0)
+        {
+            block_size = 1;
+            num_blocks = (ui32)total_size > 1 ? (ui32)total_size : 1;
+        }
+        std::atomic<ui32> blocks_running = 0;
+        for (ui32 t = 0; t < num_blocks; t++)
+        {
+            T start = ((T)(t * block_size) + the_first_index);
+            T end = (t == num_blocks - 1) ? last_index + 1 : ((T)((t + 1) * block_size) + the_first_index);
+            blocks_running++;
+            push_task([start, end, &loop, &blocks_running]
+                      {
+                          loop(start, end);
+                          blocks_running--;
+                      });
+        }
+        while (blocks_running != 0)
+        {
+            sleep_or_yield();
+        }
+    }
+
+    /**
+     * @brief Push a function with no arguments or return value into the task queue.
+     *
+     * @tparam F The type of the function.
+     * @param task The function to push.
+     */
+    template <typename F>
+    void push_task(const F &task)
+    {
+        tasks_total++;
+        {
+            const std::scoped_lock lock(queue_mutex);
+            tasks.push(std::function<void()>(task));
+        }
+    }
+
+    /**
+     * @brief Push a function with arguments, but no return value, into the task queue.
+     * @details The function is wrapped inside a lambda in order to hide the arguments, as the tasks in the queue must be of type std::function<void()>, so they cannot have any arguments or return value. If no arguments are provided, the other overload will be used, in order to avoid the (slight) overhead of using a lambda.
+     *
+     * @tparam F The type of the function.
+     * @tparam A The types of the arguments.
+     * @param task The function to push.
+     * @param args The arguments to pass to the function.
+     */
+    template <typename F, typename... A>
+    void push_task(const F &task, const A &...args)
+    {
+        push_task([task, args...]
+                  { task(args...); });
+    }
+
+    /**
+     * @brief Reset the number of threads in the pool. Waits for all currently running tasks to be completed, then destroys all threads in the pool and creates a new thread pool with the new number of threads. Any tasks that were waiting in the queue before the pool was reset will then be executed by the new threads. If the pool was paused before resetting it, the new pool will be paused as well.
+     *
+     * @param _thread_count The number of threads to use. The default value is the total number of hardware threads available, as reported by the implementation. With a hyperthreaded CPU, this will be twice the number of CPU cores. If the argument is zero, the default value will be used instead.
+     */
+    void reset(const ui32 &_thread_count = std::thread::hardware_concurrency())
+    {
+        bool was_paused = paused;
+        paused = true;
+        wait_for_tasks();
+        running = false;
+        destroy_threads();
+        thread_count = _thread_count ? _thread_count : std::thread::hardware_concurrency();
+        threads.reset(new std::thread[thread_count]);
+        paused = was_paused;
+        running = true;
+        create_threads();
+    }
+
+    /**
+     * @brief Submit a function with zero or more arguments and no return value into the task queue, and get an std::future<bool> that will be set to true upon completion of the task.
+     *
+     * @tparam F The type of the function.
+     * @tparam A The types of the zero or more arguments to pass to the function.
+     * @param task The function to submit.
+     * @param args The zero or more arguments to pass to the function.
+     * @return A future to be used later to check if the function has finished its execution.
+     */
+    template <typename F, typename... A, typename = std::enable_if_t<std::is_void_v<std::invoke_result_t<std::decay_t<F>, std::decay_t<A>...>>>>
+    std::future<bool> submit(const F &task, const A &...args)
+    {
+        std::shared_ptr<std::promise<bool>> task_promise(new std::promise<bool>);
+        std::future<bool> future = task_promise->get_future();
+        push_task([task, args..., task_promise]
+                  {
+                      try
+                      {
+                          task(args...);
+                          task_promise->set_value(true);
+                      }
+                      catch (...)
+                      {
+                          try
+                          {
+                              task_promise->set_exception(std::current_exception());
+                          }
+                          catch (...)
+                          {
+                          }
+                      }
+                  });
+        return future;
+    }
+
+    /**
+     * @brief Submit a function with zero or more arguments and a return value into the task queue, and get a future for its eventual returned value.
+     *
+     * @tparam F The type of the function.
+     * @tparam A The types of the zero or more arguments to pass to the function.
+     * @tparam R The return type of the function.
+     * @param task The function to submit.
+     * @param args The zero or more arguments to pass to the function.
+     * @return A future to be used later to obtain the function's returned value, waiting for it to finish its execution if needed.
+     */
+    template <typename F, typename... A, typename R = std::invoke_result_t<std::decay_t<F>, std::decay_t<A>...>, typename = std::enable_if_t<!std::is_void_v<R>>>
+    std::future<R> submit(const F &task, const A &...args)
+    {
+        std::shared_ptr<std::promise<R>> task_promise(new std::promise<R>);
+        std::future<R> future = task_promise->get_future();
+        push_task([task, args..., task_promise]
+                  {
+                      try
+                      {
+                          task_promise->set_value(task(args...));
+                      }
+                      catch (...)
+                      {
+                          try
+                          {
+                              task_promise->set_exception(std::current_exception());
+                          }
+                          catch (...)
+                          {
+                          }
+                      }
+                  });
+        return future;
+    }
+
+    /**
+     * @brief Wait for tasks to be completed. Normally, this function waits for all tasks, both those that are currently running in the threads and those that are still waiting in the queue. However, if the variable paused is set to true, this function only waits for the currently running tasks (otherwise it would wait forever). To wait for a specific task, use submit() instead, and call the wait() member function of the generated future.
+     */
+    void wait_for_tasks()
+    {
+        while (true)
+        {
+            if (!paused)
+            {
+                if (tasks_total == 0)
+                    break;
+            }
+            else
+            {
+                if (get_tasks_running() == 0)
+                    break;
+            }
+            sleep_or_yield();
+        }
+    }
+
+    // ===========
+    // Public data
+    // ===========
+
+    /**
+     * @brief An atomic variable indicating to the workers to pause. When set to true, the workers temporarily stop popping new tasks out of the queue, although any tasks already executed will keep running until they are done. Set to false again to resume popping tasks.
+     */
+    std::atomic<bool> paused = false;
+
+    /**
+     * @brief The duration, in microseconds, that the worker function should sleep for when it cannot find any tasks in the queue. If set to 0, then instead of sleeping, the worker function will execute std::this_thread::yield() if there are no tasks in the queue. The default value is 1000.
+     */
+    ui32 sleep_duration = 1000;
+
+private:
+    // ========================
+    // Private member functions
+    // ========================
+
+    /**
+     * @brief Create the threads in the pool and assign a worker to each thread.
+     */
+    void create_threads()
+    {
+        for (ui32 i = 0; i < thread_count; i++)
+        {
+            threads[i] = std::thread(&thread_pool::worker, this);
+        }
+    }
+
+    /**
+     * @brief Destroy the threads in the pool by joining them.
+     */
+    void destroy_threads()
+    {
+        for (ui32 i = 0; i < thread_count; i++)
+        {
+            threads[i].join();
+        }
+    }
+
+    /**
+     * @brief Try to pop a new task out of the queue.
+     *
+     * @param task A reference to the task. Will be populated with a function if the queue is not empty.
+     * @return true if a task was found, false if the queue is empty.
+     */
+    bool pop_task(std::function<void()> &task)
+    {
+        const std::scoped_lock lock(queue_mutex);
+        if (tasks.empty())
+            return false;
+        else
+        {
+            task = std::move(tasks.front());
+            tasks.pop();
+            return true;
+        }
+    }
+
+    /**
+     * @brief Sleep for sleep_duration microseconds. If that variable is set to zero, yield instead.
+     *
+     */
+    void sleep_or_yield()
+    {
+        if (sleep_duration)
+            std::this_thread::sleep_for(std::chrono::microseconds(sleep_duration));
+        else
+            std::this_thread::yield();
+    }
+
+    /**
+     * @brief A worker function to be assigned to each thread in the pool. Continuously pops tasks out of the queue and executes them, as long as the atomic variable running is set to true.
+     */
+    void worker()
+    {
+        while (running)
+        {
+            std::function<void()> task;
+            if (!paused && pop_task(task))
+            {
+                task();
+                tasks_total--;
+            }
+            else
+            {
+                sleep_or_yield();
+            }
+        }
+    }
+
+    // ============
+    // Private data
+    // ============
+
+    /**
+     * @brief A mutex to synchronize access to the task queue by different threads.
+     */
+    mutable std::mutex queue_mutex = {};
+
+    /**
+     * @brief An atomic variable indicating to the workers to keep running. When set to false, the workers permanently stop working.
+     */
+    std::atomic<bool> running = true;
+
+    /**
+     * @brief A queue of tasks to be executed by the threads.
+     */
+    std::queue<std::function<void()>> tasks = {};
+
+    /**
+     * @brief The number of threads in the pool.
+     */
+    ui32 thread_count;
+
+    /**
+     * @brief A smart pointer to manage the memory allocated for the threads.
+     */
+    std::unique_ptr<std::thread[]> threads;
+
+    /**
+     * @brief An atomic variable to keep track of the total number of unfinished tasks - either still in the queue, or running in a thread.
+     */
+    std::atomic<ui32> tasks_total = 0;
+};
+
+//                                     End class thread_pool                                     //
+// ============================================================================================= //
+
+// ============================================================================================= //
+//                                   Begin class synced_stream                                   //
+
+/**
+ * @brief A helper class to synchronize printing to an output stream by different threads.
+ */
+class synced_stream
+{
+public:
+    /**
+     * @brief Construct a new synced stream.
+     *
+     * @param _out_stream The output stream to print to. The default value is std::cout.
+     */
+    synced_stream(std::ostream &_out_stream = std::cout)
+        : out_stream(_out_stream){};
+
+    /**
+     * @brief Print any number of items into the output stream. Ensures that no other threads print to this stream simultaneously, as long as they all exclusively use this synced_stream object to print.
+     *
+     * @tparam T The types of the items
+     * @param items The items to print.
+     */
+    template <typename... T>
+    void print(const T &...items)
+    {
+        const std::scoped_lock lock(stream_mutex);
+        (out_stream << ... << items);
+    }
+
+    /**
+     * @brief Print any number of items into the output stream, followed by a newline character. Ensures that no other threads print to this stream simultaneously, as long as they all exclusively use this synced_stream object to print.
+     *
+     * @tparam T The types of the items
+     * @param items The items to print.
+     */
+    template <typename... T>
+    void println(const T &...items)
+    {
+        print(items..., '\n');
+    }
+
+private:
+    /**
+     * @brief A mutex to synchronize printing.
+     */
+    mutable std::mutex stream_mutex = {};
+
+    /**
+     * @brief The output stream to print to.
+     */
+    std::ostream &out_stream;
+};
+
+//                                    End class synced_stream                                    //
+// ============================================================================================= //
+
+// ============================================================================================= //
+//                                       Begin class timer                                       //
+
+/**
+ * @brief A helper class to measure execution time for benchmarking purposes.
+ */
+class timer
+{
+    typedef std::int_fast64_t i64;
+
+public:
+    /**
+     * @brief Start (or restart) measuring time.
+     */
+    void start()
+    {
+        start_time = std::chrono::steady_clock::now();
+    }
+
+    /**
+     * @brief Stop measuring time and store the elapsed time since start().
+     */
+    void stop()
+    {
+        elapsed_time = std::chrono::steady_clock::now() - start_time;
+    }
+
+    /**
+     * @brief Get the number of milliseconds that have elapsed between start() and stop().
+     *
+     * @return The number of milliseconds.
+     */
+    i64 ms() const
+    {
+        return (std::chrono::duration_cast<std::chrono::milliseconds>(elapsed_time)).count();
+    }
+
+private:
+    /**
+     * @brief The time point when measuring started.
+     */
+    std::chrono::time_point<std::chrono::steady_clock> start_time = std::chrono::steady_clock::now();
+
+    /**
+     * @brief The duration that has elapsed between start() and stop().
+     */
+    std::chrono::duration<double> elapsed_time = std::chrono::duration<double>::zero();
+};
+
+//                                        End class timer                                        //
+// ============================================================================================= //


### PR DESCRIPTION
Two benchmarks to measure the potential overhead of the task scheduler:
- Empty tasks: execute a certain number of empty tasks in parallel. The tasks exists, is instantiated, but does nothing
- Payload tasks: execute a certain number of tasks each taking approximatively 0.1 ms. A counter is added to compare the benchmark value to a theoretical value. The difference gives the overhead of using the task scheduler. Note that the task can take a bit more than 0.1 ms. The overhead can also be due to this.

A thread pool library has been added to compare our task scheduler to another thread pool. The same benchmarks are implemented.

The results:

```
--------------------------------------------------------------------------------------------
Benchmark                                                  Time             CPU   Iterations
--------------------------------------------------------------------------------------------
BM_TaskScheduler<EmptyTask>/1000/1/threads:1           0.016 ms        0.016 ms        40727
BM_TaskScheduler<EmptyTask>/10000/1/threads:1          0.161 ms        0.160 ms         4480
BM_TaskScheduler<EmptyTask>/100000/1/threads:1          1.96 ms         2.01 ms          373
BM_TaskScheduler<EmptyTask>/1000/2/threads:1           0.220 ms        0.222 ms         3446
BM_TaskScheduler<EmptyTask>/10000/2/threads:1           1.65 ms         1.63 ms          345
BM_TaskScheduler<EmptyTask>/100000/2/threads:1          15.3 ms         15.2 ms           41
BM_TaskScheduler<EmptyTask>/1000/4/threads:1           0.357 ms        0.360 ms         1867
BM_TaskScheduler<EmptyTask>/10000/4/threads:1           4.58 ms         4.60 ms          204
BM_TaskScheduler<EmptyTask>/100000/4/threads:1          34.5 ms         34.2 ms           21
BM_TaskScheduler<EmptyTask>/1000/8/threads:1           0.599 ms        0.593 ms          896
BM_TaskScheduler<EmptyTask>/10000/8/threads:1           6.19 ms         6.28 ms          112
BM_TaskScheduler<EmptyTask>/100000/8/threads:1          58.7 ms         59.4 ms           10
BM_TaskScheduler<EmptyTask>/1000/16/threads:1          0.862 ms        0.767 ms          896
BM_TaskScheduler<EmptyTask>/10000/16/threads:1          8.03 ms         7.81 ms          112
BM_TaskScheduler<EmptyTask>/100000/16/threads:1         94.3 ms         90.9 ms           11
BM_TaskScheduler<PayloadTask>/1000/1/threads:1           100 ms          100 ms            7 theoryMs=100
BM_TaskScheduler<PayloadTask>/10000/1/threads:1         1000 ms         1000 ms            1 theoryMs=1000
BM_TaskScheduler<PayloadTask>/100000/1/threads:1       10004 ms        10000 ms            1 theoryMs=10k
BM_TaskScheduler<PayloadTask>/1000/2/threads:1          50.1 ms         51.6 ms           10 theoryMs=50
BM_TaskScheduler<PayloadTask>/10000/2/threads:1          501 ms          500 ms            1 theoryMs=500
BM_TaskScheduler<PayloadTask>/100000/2/threads:1        5009 ms         5000 ms            1 theoryMs=5k
BM_TaskScheduler<PayloadTask>/1000/4/threads:1          25.1 ms         25.1 ms           28 theoryMs=25
BM_TaskScheduler<PayloadTask>/10000/4/threads:1          251 ms          250 ms            3 theoryMs=250
BM_TaskScheduler<PayloadTask>/100000/4/threads:1        2506 ms         2516 ms            1 theoryMs=2.5k
BM_TaskScheduler<PayloadTask>/1000/8/threads:1          12.6 ms         12.6 ms           56 theoryMs=12
BM_TaskScheduler<PayloadTask>/10000/8/threads:1          125 ms          125 ms            6 theoryMs=125
BM_TaskScheduler<PayloadTask>/100000/8/threads:1        1253 ms         1250 ms            1 theoryMs=1.25k
BM_TaskScheduler<PayloadTask>/1000/16/threads:1         6.71 ms         5.86 ms          112 theoryMs=6
BM_TaskScheduler<PayloadTask>/10000/16/threads:1        63.5 ms         61.1 ms           11 theoryMs=62
BM_TaskScheduler<PayloadTask>/100000/16/threads:1        631 ms          641 ms            1 theoryMs=625
```

```
--------------------------------------------------------------------------------------------------------
Benchmark                                                              Time             CPU   Iterations
--------------------------------------------------------------------------------------------------------
BM_ThreadPool_EmptyTasks/1000/1/threads:1                           28.5 ms        0.156 ms          100
BM_ThreadPool_EmptyTasks/10000/1/threads:1                          31.6 ms        0.000 ms          100
BM_ThreadPool_EmptyTasks/100000/1/threads:1                         36.6 ms         10.2 ms          100
BM_ThreadPool_EmptyTasks/1000/2/threads:1                           29.6 ms        0.000 ms          100
BM_ThreadPool_EmptyTasks/10000/2/threads:1                          37.6 ms         1.25 ms          100
BM_ThreadPool_EmptyTasks/100000/2/threads:1                         44.9 ms         10.0 ms           75
BM_ThreadPool_EmptyTasks/1000/4/threads:1                           34.5 ms        0.156 ms          100
BM_ThreadPool_EmptyTasks/10000/4/threads:1                          39.0 ms        0.938 ms          100
BM_ThreadPool_EmptyTasks/100000/4/threads:1                         44.0 ms         9.53 ms          100
BM_ThreadPool_EmptyTasks/1000/8/threads:1                           34.6 ms        0.000 ms          100
BM_ThreadPool_EmptyTasks/10000/8/threads:1                          39.0 ms         1.09 ms          100
BM_ThreadPool_EmptyTasks/100000/8/threads:1                         46.7 ms         7.03 ms          100
BM_ThreadPool_EmptyTasks/1000/16/threads:1                          33.2 ms        0.156 ms          100
BM_ThreadPool_EmptyTasks/10000/16/threads:1                         37.6 ms         1.09 ms          100
BM_ThreadPool_EmptyTasks/100000/16/threads:1                        49.6 ms         7.11 ms          112
BM_ThreadPool_PayloadTask/1000/1/threads:1                           121 ms        0.000 ms          100 theoryMs=100
BM_ThreadPool_PayloadTask/10000/1/threads:1                         1023 ms         1.56 ms           10 theoryMs=1000
BM_ThreadPool_PayloadTask/100000/1/threads:1                       10049 ms        0.000 ms            1 theoryMs=10k
BM_ThreadPool_PayloadTask/1000/2/threads:1                          75.8 ms        0.000 ms          100 theoryMs=50
BM_ThreadPool_PayloadTask/10000/2/threads:1                          525 ms        0.000 ms           10 theoryMs=500
BM_ThreadPool_PayloadTask/100000/2/threads:1                        5041 ms        0.000 ms            1 theoryMs=5k
BM_ThreadPool_PayloadTask/1000/4/threads:1                          47.6 ms        0.000 ms          100 theoryMs=25
BM_ThreadPool_PayloadTask/10000/4/threads:1                          266 ms        0.000 ms           10 theoryMs=250
BM_ThreadPool_PayloadTask/100000/4/threads:1                        2538 ms         15.6 ms            1 theoryMs=2.5k
BM_ThreadPool_PayloadTask/1000/8/threads:1                          34.2 ms        0.000 ms          100 theoryMs=12
BM_ThreadPool_PayloadTask/10000/8/threads:1                          148 ms        0.312 ms          100 theoryMs=125
BM_ThreadPool_PayloadTask/100000/8/threads:1                        1286 ms         7.81 ms           10 theoryMs=1.25k
BM_ThreadPool_PayloadTask/1000/16/threads:1                         34.1 ms        0.000 ms          100 theoryMs=6
BM_ThreadPool_PayloadTask/10000/16/threads:1                        94.0 ms        0.156 ms          100 theoryMs=62
BM_ThreadPool_PayloadTask/100000/16/threads:1                        665 ms         7.81 ms           10 theoryMs=625
BM_ThreadPool_PayloadTask_ParallelizeLoop/1000/1/threads:1           120 ms        0.000 ms          100 theoryMs=100
BM_ThreadPool_PayloadTask_ParallelizeLoop/10000/1/threads:1         1017 ms        0.000 ms           10 theoryMs=1000
BM_ThreadPool_PayloadTask_ParallelizeLoop/100000/1/threads:1       10023 ms        0.000 ms            1 theoryMs=10k
BM_ThreadPool_PayloadTask_ParallelizeLoop/1000/2/threads:1          77.3 ms        0.000 ms          100 theoryMs=50
BM_ThreadPool_PayloadTask_ParallelizeLoop/10000/2/threads:1          526 ms        0.000 ms           10 theoryMs=500
BM_ThreadPool_PayloadTask_ParallelizeLoop/100000/2/threads:1        5018 ms        0.000 ms            1 theoryMs=5k
BM_ThreadPool_PayloadTask_ParallelizeLoop/1000/4/threads:1          50.8 ms        0.000 ms          100 theoryMs=25
BM_ThreadPool_PayloadTask_ParallelizeLoop/10000/4/threads:1          269 ms        0.000 ms           10 theoryMs=250
BM_ThreadPool_PayloadTask_ParallelizeLoop/100000/4/threads:1        2535 ms        0.000 ms            1 theoryMs=2.5k
BM_ThreadPool_PayloadTask_ParallelizeLoop/1000/8/threads:1          37.3 ms        0.000 ms          100 theoryMs=12
BM_ThreadPool_PayloadTask_ParallelizeLoop/10000/8/threads:1          157 ms        0.000 ms          100 theoryMs=125
BM_ThreadPool_PayloadTask_ParallelizeLoop/100000/8/threads:1        1282 ms        0.000 ms           10 theoryMs=1.25k
BM_ThreadPool_PayloadTask_ParallelizeLoop/1000/16/threads:1         30.6 ms        0.000 ms          100 theoryMs=6
BM_ThreadPool_PayloadTask_ParallelizeLoop/10000/16/threads:1         106 ms        0.000 ms          100 theoryMs=62
BM_ThreadPool_PayloadTask_ParallelizeLoop/100000/16/threads:1        691 ms        0.000 ms           10 theoryMs=625

```

Conclusion: **IF** the benchmarks are relevent, our task scheduler is not that bad.