### PR TITLE
More benchmarks on AdvancedTimer

### DIFF
--- a/src/benchmarks/SofaHelper/AdvancedTimer.cpp
+++ b/src/benchmarks/SofaHelper/AdvancedTimer.cpp
@@ -1,9 +1,25 @@
+#include <sstream>
 #include <benchmark/benchmark.h>
 #include <sofa/helper/AdvancedTimer.h>
 
 ///Evaluates the overhead of a call to AdvancedTimer
 static void BM_AdvancedTimer_begin_end(benchmark::State& state);
 BENCHMARK(BM_AdvancedTimer_begin_end);
+
+static void BM_AdvancedTimer_largeNumberTimers(benchmark::State& state);
+BENCHMARK(BM_AdvancedTimer_largeNumberTimers)->Range(8 << 4, 8 << 11)->Unit(benchmark::kMillisecond);
+
+static void BM_AdvancedTimer_deepTreeEnabled(benchmark::State& state);
+BENCHMARK(BM_AdvancedTimer_deepTreeEnabled)->ArgsProduct({
+    benchmark::CreateRange(1, 1 << 6, 2),
+    benchmark::CreateDenseRange(2, 4, 1)
+})->Unit(benchmark::kMillisecond);
+
+static void BM_AdvancedTimer_deepTreeDisabled(benchmark::State& state);
+BENCHMARK(BM_AdvancedTimer_deepTreeDisabled)->ArgsProduct({
+    benchmark::CreateRange(1, 1 << 6, 2),
+    benchmark::CreateDenseRange(2, 4, 1)
+})->Unit(benchmark::kMillisecond);
 
 void BM_AdvancedTimer_begin_end(benchmark::State &state)
 {
@@ -12,4 +28,67 @@ void BM_AdvancedTimer_begin_end(benchmark::State &state)
         sofa::helper::AdvancedTimer::begin("Animate");
         sofa::helper::AdvancedTimer::end("Animate");
     }
+}
+
+void BM_AdvancedTimer_largeNumberTimers(benchmark::State& state)
+{
+    for (auto _ : state)
+    {
+        sofa::helper::AdvancedTimer::begin("Animate");
+        for (int64_t i = 0; i < state.range(0); ++i)
+        {
+            const auto iStr = std::to_string(i);
+            sofa::helper::AdvancedTimer::stepBegin(iStr);
+            sofa::helper::AdvancedTimer::stepEnd(iStr);
+        }
+        sofa::helper::AdvancedTimer::end("Animate");
+    }
+}
+
+void subStep(int64_t depth, int64_t i, int64_t nbTimers, int64_t maxDepth, int64_t& timersCounter)
+{
+    if (depth == maxDepth)
+        return;
+
+    std::stringstream ss;
+    ss << "timer_" << depth << "-" << i;
+    sofa::helper::AdvancedTimer::stepBegin(ss.str());
+    ++timersCounter;
+
+    for (unsigned int j = 0; j < nbTimers; ++j)
+    {
+        subStep(depth + 1, j, nbTimers, maxDepth, timersCounter);
+    }
+
+    sofa::helper::AdvancedTimer::stepEnd(ss.str());
+}
+
+void advancedTimerDeepTree(benchmark::State& state)
+{
+    int64_t timersCounter {};
+    for (auto _ : state)
+    {
+        timersCounter = 0;
+        sofa::helper::AdvancedTimer::begin("Animate");
+
+        for (int64_t i = 0; i < state.range(0); ++i)
+        {
+            subStep(0, i, state.range(0), state.range(1), timersCounter);
+        }
+
+        sofa::helper::AdvancedTimer::end("Animate");
+    }
+    state.counters["nbTimers"] = benchmark::Counter( timersCounter);
+}
+
+void BM_AdvancedTimer_deepTreeEnabled(benchmark::State& state)
+{
+    sofa::helper::AdvancedTimer::setEnabled("Animate", true);
+    advancedTimerDeepTree(state);
+}
+
+void BM_AdvancedTimer_deepTreeDisabled(benchmark::State& state)
+{
+    sofa::helper::AdvancedTimer::setEnabled("Animate", false);
+    advancedTimerDeepTree(state);
 }

--- a/src/benchmarks/SofaHelper/AdvancedTimer.cpp
+++ b/src/benchmarks/SofaHelper/AdvancedTimer.cpp
@@ -84,6 +84,8 @@ void advancedTimerDeepTree(benchmark::State& state)
 void BM_AdvancedTimer_deepTreeEnabled(benchmark::State& state)
 {
     sofa::helper::AdvancedTimer::setEnabled("Animate", true);
+    sofa::helper::AdvancedTimer::setInterval("Animate", 1);
+    sofa::helper::AdvancedTimer::setOutputType("Animate", "gui");
     advancedTimerDeepTree(state);
 }
 


### PR DESCRIPTION
The results:

```
-------------------------------------------------------------------------------------------------
Benchmark                                       Time             CPU   Iterations UserCounters...
-------------------------------------------------------------------------------------------------
BM_AdvancedTimer_deepTreeEnabled/1/2        0.002 ms        0.002 ms       373333 nbTimers=2
BM_AdvancedTimer_deepTreeEnabled/2/2        0.005 ms        0.005 ms       112000 nbTimers=6
BM_AdvancedTimer_deepTreeEnabled/4/2        0.016 ms        0.016 ms        40727 nbTimers=20
BM_AdvancedTimer_deepTreeEnabled/8/2        0.061 ms        0.061 ms        11200 nbTimers=72
BM_AdvancedTimer_deepTreeEnabled/16/2       0.236 ms        0.241 ms         2987 nbTimers=272
BM_AdvancedTimer_deepTreeEnabled/32/2       0.945 ms        0.941 ms          747 nbTimers=1056
BM_AdvancedTimer_deepTreeEnabled/64/2        3.94 ms         3.93 ms          179 nbTimers=4.16k
BM_AdvancedTimer_deepTreeEnabled/1/3        0.003 ms        0.003 ms       263529 nbTimers=3
BM_AdvancedTimer_deepTreeEnabled/2/3        0.012 ms        0.012 ms        56000 nbTimers=14
BM_AdvancedTimer_deepTreeEnabled/4/3        0.074 ms        0.073 ms         8960 nbTimers=84
BM_AdvancedTimer_deepTreeEnabled/8/3        0.522 ms        0.516 ms         1000 nbTimers=584
BM_AdvancedTimer_deepTreeEnabled/16/3        4.04 ms         4.00 ms          172 nbTimers=4.368k
BM_AdvancedTimer_deepTreeEnabled/32/3        32.0 ms         32.0 ms           21 nbTimers=33.824k
BM_AdvancedTimer_deepTreeEnabled/64/3         262 ms          266 ms            2 nbTimers=266.304k
BM_AdvancedTimer_deepTreeEnabled/1/4        0.004 ms        0.003 ms       194783 nbTimers=4
BM_AdvancedTimer_deepTreeEnabled/2/4        0.027 ms        0.026 ms        24889 nbTimers=30
BM_AdvancedTimer_deepTreeEnabled/4/4        0.315 ms        0.318 ms         2358 nbTimers=340
BM_AdvancedTimer_deepTreeEnabled/8/4         4.26 ms         4.24 ms          166 nbTimers=4.68k
BM_AdvancedTimer_deepTreeEnabled/16/4        65.3 ms         65.3 ms           11 nbTimers=69.904k
BM_AdvancedTimer_deepTreeEnabled/32/4        1075 ms         1078 ms            1 nbTimers=1082.4k
BM_AdvancedTimer_deepTreeEnabled/64/4       18115 ms        18109 ms            1 nbTimers=17.0435M
BM_AdvancedTimer_deepTreeDisabled/1/2       0.002 ms        0.002 ms       448000 nbTimers=2
BM_AdvancedTimer_deepTreeDisabled/2/2       0.005 ms        0.005 ms       100000 nbTimers=6
BM_AdvancedTimer_deepTreeDisabled/4/2       0.016 ms        0.015 ms        44800 nbTimers=20
BM_AdvancedTimer_deepTreeDisabled/8/2       0.059 ms        0.057 ms        11200 nbTimers=72
BM_AdvancedTimer_deepTreeDisabled/16/2      0.229 ms        0.229 ms         3200 nbTimers=272
BM_AdvancedTimer_deepTreeDisabled/32/2      0.888 ms        0.879 ms          747 nbTimers=1056
BM_AdvancedTimer_deepTreeDisabled/64/2       3.81 ms         3.75 ms          179 nbTimers=4.16k
BM_AdvancedTimer_deepTreeDisabled/1/3       0.002 ms        0.003 ms       280000 nbTimers=3
BM_AdvancedTimer_deepTreeDisabled/2/3       0.011 ms        0.011 ms        64000 nbTimers=14
BM_AdvancedTimer_deepTreeDisabled/4/3       0.067 ms        0.067 ms        11200 nbTimers=84
BM_AdvancedTimer_deepTreeDisabled/8/3       0.480 ms        0.476 ms         1445 nbTimers=584
BM_AdvancedTimer_deepTreeDisabled/16/3       3.63 ms         3.68 ms          204 nbTimers=4.368k
BM_AdvancedTimer_deepTreeDisabled/32/3       29.0 ms         28.8 ms           25 nbTimers=33.824k
BM_AdvancedTimer_deepTreeDisabled/64/3        243 ms          245 ms            3 nbTimers=266.304k
BM_AdvancedTimer_deepTreeDisabled/1/4       0.003 ms        0.003 ms       224000 nbTimers=4
BM_AdvancedTimer_deepTreeDisabled/2/4       0.024 ms        0.024 ms        29867 nbTimers=30
BM_AdvancedTimer_deepTreeDisabled/4/4       0.273 ms        0.270 ms         2489 nbTimers=340
BM_AdvancedTimer_deepTreeDisabled/8/4        3.84 ms         3.84 ms          187 nbTimers=4.68k
BM_AdvancedTimer_deepTreeDisabled/16/4       58.4 ms         58.2 ms           11 nbTimers=69.904k
BM_AdvancedTimer_deepTreeDisabled/32/4        949 ms          953 ms            1 nbTimers=1082.4k
BM_AdvancedTimer_deepTreeDisabled/64/4      15556 ms        15562 ms            1 nbTimers=17.0435M
```


For example, the scene https://github.com/sofa-framework/sofa/blob/master/examples/Benchmark/Performance/benchmark_cubes.scn produces between 2k and 4k timers. Which means, the only fact to have timers, enabled or not, takes ~3ms. It is not neglectable regarding the duration of a frame. I suggest a more efficient way to disable the timers.