### PR TITLE
Reduce benchmark overhead

### DIFF
--- a/src/benchmarks/SofaHelper/AdvancedTimer.cpp
+++ b/src/benchmarks/SofaHelper/AdvancedTimer.cpp
@@ -30,6 +30,15 @@ void BM_AdvancedTimer_begin_end(benchmark::State &state)
     }
 }
 
+
+static const std::vector<std::string> listTimerNames = []()
+{
+    std::vector<std::string> names;
+    std::generate_n(std::back_inserter(names), 1.1 * std::pow(1 << 6, 4), [n = 0]() mutable { return std::to_string(n++);});
+    return names;
+}();
+
+
 void BM_AdvancedTimer_largeNumberTimers(benchmark::State& state)
 {
     for (auto _ : state)
@@ -37,9 +46,9 @@ void BM_AdvancedTimer_largeNumberTimers(benchmark::State& state)
         sofa::helper::AdvancedTimer::begin("Animate");
         for (int64_t i = 0; i < state.range(0); ++i)
         {
-            const auto iStr = std::to_string(i);
-            sofa::helper::AdvancedTimer::stepBegin(iStr);
-            sofa::helper::AdvancedTimer::stepEnd(iStr);
+            const auto& timerName = listTimerNames[i];
+            sofa::helper::AdvancedTimer::stepBegin(timerName);
+            sofa::helper::AdvancedTimer::stepEnd(timerName);
         }
         sofa::helper::AdvancedTimer::end("Animate");
     }
@@ -50,9 +59,8 @@ void subStep(int64_t depth, int64_t i, int64_t nbTimers, int64_t maxDepth, int64
     if (depth == maxDepth)
         return;
 
-    std::stringstream ss;
-    ss << "timer_" << depth << "-" << i;
-    sofa::helper::AdvancedTimer::stepBegin(ss.str());
+    const auto& timerName = listTimerNames[timersCounter];
+    sofa::helper::AdvancedTimer::stepBegin(timerName);
     ++timersCounter;
 
     for (unsigned int j = 0; j < nbTimers; ++j)
@@ -60,7 +68,7 @@ void subStep(int64_t depth, int64_t i, int64_t nbTimers, int64_t maxDepth, int64
         subStep(depth + 1, j, nbTimers, maxDepth, timersCounter);
     }
 
-    sofa::helper::AdvancedTimer::stepEnd(ss.str());
+    sofa::helper::AdvancedTimer::stepEnd(timerName);
 }
 
 void advancedTimerDeepTree(benchmark::State& state)


### PR DESCRIPTION
Benchmarks were artificially heavier than what it is supposed to measure.

New measures:

```
-------------------------------------------------------------------------------------------------
Benchmark                                       Time             CPU   Iterations UserCounters...
-------------------------------------------------------------------------------------------------
BM_AdvancedTimer_deepTreeDisabled/1/2       0.000 ms        0.000 ms      4480000 nbTimers=2
BM_AdvancedTimer_deepTreeDisabled/2/2       0.000 ms        0.000 ms      1792000 nbTimers=6
BM_AdvancedTimer_deepTreeDisabled/4/2       0.001 ms        0.001 ms       497778 nbTimers=20
BM_AdvancedTimer_deepTreeDisabled/8/2       0.007 ms        0.007 ms       100000 nbTimers=72
BM_AdvancedTimer_deepTreeDisabled/16/2      0.039 ms        0.038 ms        17920 nbTimers=272
BM_AdvancedTimer_deepTreeDisabled/32/2      0.198 ms        0.201 ms         3733 nbTimers=1056
BM_AdvancedTimer_deepTreeDisabled/64/2       1.09 ms         1.07 ms          640 nbTimers=4.16k
BM_AdvancedTimer_deepTreeDisabled/1/3       0.000 ms        0.000 ms      1723077 nbTimers=3
BM_AdvancedTimer_deepTreeDisabled/2/3       0.002 ms        0.002 ms       373333 nbTimers=14
BM_AdvancedTimer_deepTreeDisabled/4/3       0.013 ms        0.013 ms        49778 nbTimers=84
BM_AdvancedTimer_deepTreeDisabled/8/3       0.119 ms        0.120 ms         6400 nbTimers=584
BM_AdvancedTimer_deepTreeDisabled/16/3      0.930 ms        0.942 ms          896 nbTimers=4.368k
BM_AdvancedTimer_deepTreeDisabled/32/3       8.53 ms         8.33 ms           75 nbTimers=33.824k
BM_AdvancedTimer_deepTreeDisabled/64/3       92.7 ms         93.8 ms            7 nbTimers=266.304k
BM_AdvancedTimer_deepTreeDisabled/1/4       0.001 ms        0.001 ms       896000 nbTimers=4
BM_AdvancedTimer_deepTreeDisabled/2/4       0.007 ms        0.007 ms       112000 nbTimers=30
BM_AdvancedTimer_deepTreeDisabled/4/4       0.103 ms        0.103 ms         6400 nbTimers=340
BM_AdvancedTimer_deepTreeDisabled/8/4        1.58 ms         1.57 ms          407 nbTimers=4.68k
BM_AdvancedTimer_deepTreeDisabled/16/4       20.1 ms         20.0 ms           32 nbTimers=69.904k
BM_AdvancedTimer_deepTreeDisabled/32/4        643 ms          641 ms            1 nbTimers=1082.4k
BM_AdvancedTimer_deepTreeDisabled/64/4      13604 ms        13594 ms            1 nbTimers=17.0435M
```