### PR TITLE
Compare Eigen/CRS compression and product

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,9 +29,12 @@ set(SOURCE_FILES ${SOFABENCHMARK_SRC}/Main.cpp)
 list(APPEND HEADER_FILES
     ${SOFABENCHMARK_SRC}/benchmarks/SofaCore/NarrowPhaseDetection.h
     ${SOFABENCHMARK_SRC}/utils/RandomValuePool.h
+    ${SOFABENCHMARK_SRC}/utils/SparseMatrix.h
     ${SOFABENCHMARK_SRC}/utils/thread_pool.hpp
 )
 list(APPEND SOURCE_FILES
+    ${SOFABENCHMARK_SRC}/benchmarks/Sofa.LinearAlgebra/SparseMatrixCompression.cpp
+    ${SOFABENCHMARK_SRC}/benchmarks/Sofa.LinearAlgebra/SparseMatrixMulTranspose.cpp
     ${SOFABENCHMARK_SRC}/benchmarks/Sofa.LinearAlgebra/SparseMatrixProduct.cpp
     ${SOFABENCHMARK_SRC}/benchmarks/Sofa.Type/Matrix.cpp
     ${SOFABENCHMARK_SRC}/benchmarks/Sofa.Type/Vec.cpp

--- a/src/benchmarks/Sofa.LinearAlgebra/SparseMatrixCompression.cpp
+++ b/src/benchmarks/Sofa.LinearAlgebra/SparseMatrixCompression.cpp
@@ -1,0 +1,72 @@
+#include <iostream>
+#include <benchmark/benchmark.h>
+#include <utils/RandomValuePool.h>
+#include <sofa/linearalgebra/CompressedRowSparseMatrix.h>
+#include <Eigen/Sparse>
+
+constexpr int64_t minMatrixSize = 1 << 9;
+constexpr int64_t maxMatrixSize = 1 << 12;
+constexpr int64_t nbMaxNonZeros = maxMatrixSize * maxMatrixSize * 150 / 1000 + 1;
+
+template<class TReal>
+static void BM_SparseMatrixCompression_Eigen(benchmark::State& state)
+{
+    const auto matrixSize = state.range(0);
+    const auto sparsityPerMil = state.range(1);
+    const auto sparsity = static_cast<TReal>(sparsityPerMil) / 1000.; //since only integers can be passed as an argument, a number between 0 and 1000 must be provided
+    const auto nbNonZero = static_cast<Eigen::Index>(sparsity * static_cast<TReal>(matrixSize*matrixSize));
+
+    const auto& values = RandomValuePool<TReal, nbMaxNonZeros>::get();
+
+    const auto& indices_x = RandomValuePool<sofa::SignedIndex, nbMaxNonZeros>::get();
+    const auto& indices_y = RandomValuePool<sofa::SignedIndex, nbMaxNonZeros+1>::get(); //not the same size to generate other values
+
+    for (auto _ : state)
+    {
+        Eigen::SparseMatrix<TReal> matrix;
+        matrix.resize(matrixSize, matrixSize);
+
+        sofa::type::vector<Eigen::Triplet<TReal> > triplets;
+        for (Eigen::Index i = 0; i < nbNonZero; ++i)
+        {
+            triplets.emplace_back(indices_x[i], indices_y[i], values[i]);
+        }
+        matrix.setFromTriplets(triplets.begin(), triplets.end());
+    }
+
+    state.counters["nbNonZero"] = benchmark::Counter(nbNonZero);
+}
+
+template<class TReal>
+static void BM_SparseMatrixCompression_CRS(benchmark::State& state)
+{
+    const auto matrixSize = state.range(0);
+    const auto sparsityPerMil = state.range(1);
+    const auto sparsity = static_cast<TReal>(sparsityPerMil) / 1000.; //since only integers can be passed as an argument, a number between 0 and 1000 must be provided
+    const auto nbNonZero = static_cast<sofa::SignedIndex>(sparsity * static_cast<TReal>(matrixSize*matrixSize));
+
+    const auto& values = RandomValuePool<TReal, nbMaxNonZeros>::get();
+
+    const auto& indices_x = RandomValuePool<sofa::SignedIndex, nbMaxNonZeros>::get();
+    const auto& indices_y = RandomValuePool<sofa::SignedIndex, nbMaxNonZeros+1>::get(); //not the same size to generate other values
+
+    for (auto _ : state)
+    {
+        sofa::linearalgebra::CompressedRowSparseMatrix<TReal> matrix;
+
+        matrix.resize(matrixSize, matrixSize);
+
+        for (unsigned int i = 0; i < nbNonZero; ++i)
+        {
+            matrix.add(indices_x[i], indices_y[i], values[i]);
+        }
+
+        matrix.compress();
+    }
+
+    state.counters["nbNonZero"] = benchmark::Counter(nbNonZero);
+}
+
+
+BENCHMARK_TEMPLATE(BM_SparseMatrixCompression_Eigen, SReal)->ArgsProduct({benchmark::CreateRange(minMatrixSize, maxMatrixSize, 2), {10, 20, 100, 150}})->Unit(benchmark::kMicrosecond);
+BENCHMARK_TEMPLATE(BM_SparseMatrixCompression_CRS, SReal)->ArgsProduct({benchmark::CreateRange(minMatrixSize, maxMatrixSize, 2), {10, 20, 100, 150}})->Unit(benchmark::kMicrosecond);

--- a/src/benchmarks/Sofa.LinearAlgebra/SparseMatrixMulTranspose.cpp
+++ b/src/benchmarks/Sofa.LinearAlgebra/SparseMatrixMulTranspose.cpp
@@ -1,0 +1,98 @@
+#include <iostream>
+#include <benchmark/benchmark.h>
+#include <utils/RandomValuePool.h>
+#include <sofa/linearalgebra/CompressedRowSparseMatrix.h>
+#include <Eigen/Sparse>
+
+constexpr int64_t minMatrixSize = 1 << 9;
+constexpr int64_t maxMatrixSize = 1 << 12;
+constexpr int64_t nbMaxNonZeros = maxMatrixSize * maxMatrixSize * 150 / 1000 + 1;
+
+template<class TReal>
+static void BM_SparseMatrixMulTranspose_Eigen(benchmark::State& state)
+{
+    const auto matrixSize = state.range(0);
+    const auto sparsityPerMil = state.range(1);
+    const auto sparsity = static_cast<TReal>(sparsityPerMil) / 1000.; //since only integers can be passed as an argument, a number between 0 and 1000 must be provided
+    const auto nbNonZero = static_cast<Eigen::Index>(sparsity * static_cast<TReal>(matrixSize*matrixSize));
+
+    const auto& values_a = RandomValuePool<TReal, nbMaxNonZeros>::get();
+    const auto& values_b = RandomValuePool<TReal, nbMaxNonZeros + 1>::get();
+
+    const auto& indices_a_x = RandomValuePool<sofa::SignedIndex, nbMaxNonZeros>::get();
+    const auto& indices_a_y = RandomValuePool<sofa::SignedIndex, nbMaxNonZeros+1>::get();
+    const auto& indices_b_x = RandomValuePool<sofa::SignedIndex, nbMaxNonZeros+2>::get();
+    const auto& indices_b_y = RandomValuePool<sofa::SignedIndex, nbMaxNonZeros+3>::get();
+
+    Eigen::SparseMatrix<TReal> matrix_a, matrix_b;
+    matrix_a.resize(matrixSize, matrixSize);
+    matrix_b.resize(matrixSize, matrixSize);
+
+    {
+        sofa::type::vector<Eigen::Triplet<TReal> > triplets_a;
+        for (Eigen::Index i = 0; i < nbNonZero; ++i)
+        {
+            triplets_a.emplace_back(indices_a_x[i], indices_a_y[i], values_a[i]);
+        }
+        matrix_a.setFromTriplets(triplets_a.begin(), triplets_a.end());
+    }
+    {
+        sofa::type::vector<Eigen::Triplet<TReal> > triplets_b;
+        for (Eigen::Index i = 0; i < nbNonZero; ++i)
+        {
+            triplets_b.emplace_back(indices_b_x[i], indices_b_y[i], values_b[i]);
+        }
+        matrix_b.setFromTriplets(triplets_b.begin(), triplets_b.end());
+    }
+
+    for (auto _ : state)
+    {
+        Eigen::SparseMatrix<TReal> res;
+        benchmark::DoNotOptimize(res = matrix_a.transpose() * matrix_b);
+    }
+
+    state.counters["nbNonZero"] = benchmark::Counter(nbNonZero);
+}
+
+template<class TReal>
+static void BM_SparseMatrixMulTranspose_CRS(benchmark::State& state)
+{
+    const auto matrixSize = state.range(0);
+    const auto sparsityPerMil = state.range(1);
+    const auto sparsity = static_cast<TReal>(sparsityPerMil) / 1000.; //since only integers can be passed as an argument, a number between 0 and 1000 must be provided
+    const auto nbNonZero = static_cast<sofa::SignedIndex>(sparsity * static_cast<TReal>(matrixSize*matrixSize));
+
+    const auto& values_a = RandomValuePool<TReal, nbMaxNonZeros>::get();
+    const auto& values_b = RandomValuePool<TReal, nbMaxNonZeros + 1>::get();
+
+    const auto& indices_a_x = RandomValuePool<sofa::SignedIndex, nbMaxNonZeros>::get();
+    const auto& indices_a_y = RandomValuePool<sofa::SignedIndex, nbMaxNonZeros+1>::get();
+    const auto& indices_b_x = RandomValuePool<sofa::SignedIndex, nbMaxNonZeros+2>::get();
+    const auto& indices_b_y = RandomValuePool<sofa::SignedIndex, nbMaxNonZeros+3>::get();
+
+    sofa::linearalgebra::CompressedRowSparseMatrix<TReal> matrix_a, matrix_b;
+
+    matrix_a.resize(matrixSize, matrixSize);
+    matrix_b.resize(matrixSize, matrixSize);
+
+    for (unsigned int i = 0; i < nbNonZero; ++i)
+    {
+        matrix_a.add(indices_a_x[i], indices_a_y[i], values_a[i]);
+        matrix_b.add(indices_b_x[i], indices_b_y[i], values_b[i]);
+    }
+
+    matrix_a.compress();
+    matrix_b.compress();
+
+    for (auto _ : state)
+    {
+        sofa::linearalgebra::CompressedRowSparseMatrix<TReal> res;
+        matrix_a.mulTranspose(res, matrix_b);
+    }
+
+    state.counters["nbNonZero"] = benchmark::Counter(nbNonZero);
+}
+
+
+BENCHMARK_TEMPLATE(BM_SparseMatrixMulTranspose_Eigen, SReal)->ArgsProduct({benchmark::CreateRange(minMatrixSize, maxMatrixSize, 2), {10, 20, 100, 150}})->Unit(benchmark::kMicrosecond);
+BENCHMARK_TEMPLATE(BM_SparseMatrixMulTranspose_CRS, SReal)->ArgsProduct({benchmark::CreateRange(minMatrixSize, maxMatrixSize, 2), {10, 20, 100, 150}})->Unit(benchmark::kMicrosecond);

--- a/src/benchmarks/Sofa.LinearAlgebra/SparseMatrixProduct.cpp
+++ b/src/benchmarks/Sofa.LinearAlgebra/SparseMatrixProduct.cpp
@@ -2,28 +2,9 @@
 #include <benchmark/benchmark.h>
 
 #include <sofa/linearalgebra/SparseMatrixProduct[EigenSparseMatrix].h>
+#include <utils/SparseMatrix.h>
 
-#include <sofa/helper/random.h>
 
-/// Sparsity is a ratio between 0 and 1
-template <typename TReal = SReal>
-static void generateRandomSparseMatrix(Eigen::SparseMatrix<TReal>& eigenMatrix, Eigen::Index nbRows, Eigen::Index nbCols, TReal sparsity)
-{
-    eigenMatrix.resize(nbRows, nbCols);
-    sofa::type::vector<Eigen::Triplet<TReal> > triplets;
-
-    const auto nbNonZero = static_cast<Eigen::Index>(sparsity * static_cast<TReal>(nbRows*nbCols));
-
-    for (Eigen::Index i = 0; i < nbNonZero; ++i)
-    {
-        const auto value = static_cast<TReal>(sofa::helper::drand(1));
-        const auto row = static_cast<Eigen::Index>(sofa::helper::drandpos(nbRows) - 1e-8);
-        const auto col = static_cast<Eigen::Index>(sofa::helper::drandpos(nbCols) - 1e-8);
-        triplets.emplace_back(row, col, value);
-    }
-
-    eigenMatrix.setFromTriplets(triplets.begin(), triplets.end());
-}
 
 template<class TMatrix>
 class BM_SparseMatrixProduct : public benchmark::Fixture

--- a/src/utils/SparseMatrix.h
+++ b/src/utils/SparseMatrix.h
@@ -1,0 +1,24 @@
+#pragma once
+#include <Eigen/Sparse>
+#include <sofa/helper/random.h>
+#include <sofa/config.h>
+
+/// Sparsity is a ratio between 0 and 1
+template <typename TReal = SReal>
+static void generateRandomSparseMatrix(Eigen::SparseMatrix<TReal>& eigenMatrix, Eigen::Index nbRows, Eigen::Index nbCols, TReal sparsity)
+{
+    eigenMatrix.resize(nbRows, nbCols);
+    sofa::type::vector<Eigen::Triplet<TReal> > triplets;
+
+    const auto nbNonZero = static_cast<Eigen::Index>(sparsity * static_cast<TReal>(nbRows*nbCols));
+
+    for (Eigen::Index i = 0; i < nbNonZero; ++i)
+    {
+        const auto value = static_cast<TReal>(sofa::helper::drand(1));
+        const auto row = static_cast<Eigen::Index>(sofa::helper::drandpos(nbRows) - 1e-8);
+        const auto col = static_cast<Eigen::Index>(sofa::helper::drandpos(nbCols) - 1e-8);
+        triplets.emplace_back(row, col, value);
+    }
+
+    eigenMatrix.setFromTriplets(triplets.begin(), triplets.end());
+}


### PR DESCRIPTION
Two more benchmarks:

1. Compression of sparse matrices: comparison between Eigen and `sofa::linearalgebra::CompressedRowSparseMatrix`.
2. Product A^T * B: comparison between Eigen (`matrix_a.transpose() * matrix_b`) and `sofa::linearalgebra::CompressedRowSparseMatrix::mulTranspose`.

# Results

First parameter: size of the matrix
Second parameter: sparsity in per mil.

## Compression

```
-----------------------------------------------------------------------------------------------------------
Benchmark                                                 Time             CPU   Iterations UserCounters...
-----------------------------------------------------------------------------------------------------------
BM_SparseMatrixCompression_Eigen<SReal>/512/10         20.1 us         20.0 us        32000 nbNonZero=2.621k
BM_SparseMatrixCompression_Eigen<SReal>/1024/10        84.9 us         85.8 us         7467 nbNonZero=10.485k
BM_SparseMatrixCompression_Eigen<SReal>/2048/10         310 us          308 us         2133 nbNonZero=41.943k
BM_SparseMatrixCompression_Eigen<SReal>/4096/10        2208 us         2195 us          299 nbNonZero=167.772k
BM_SparseMatrixCompression_Eigen<SReal>/512/20         34.7 us         34.5 us        19478 nbNonZero=5.242k
BM_SparseMatrixCompression_Eigen<SReal>/1024/20         171 us          169 us         4073 nbNonZero=20.971k
BM_SparseMatrixCompression_Eigen<SReal>/2048/20         695 us          711 us         1120 nbNonZero=83.886k
BM_SparseMatrixCompression_Eigen<SReal>/4096/20        5241 us         5312 us          100 nbNonZero=335.544k
BM_SparseMatrixCompression_Eigen<SReal>/512/100         194 us          195 us         3446 nbNonZero=26.214k
BM_SparseMatrixCompression_Eigen<SReal>/1024/100       1089 us         1099 us          640 nbNonZero=104.857k
BM_SparseMatrixCompression_Eigen<SReal>/2048/100       6071 us         5999 us          112 nbNonZero=419.43k
BM_SparseMatrixCompression_Eigen<SReal>/4096/100      31479 us        31250 us           22 nbNonZero=1.67772M
BM_SparseMatrixCompression_Eigen<SReal>/512/150         262 us          261 us         2635 nbNonZero=39.321k
BM_SparseMatrixCompression_Eigen<SReal>/1024/150       2109 us         2100 us          320 nbNonZero=157.286k
BM_SparseMatrixCompression_Eigen<SReal>/2048/150       9611 us         9792 us           75 nbNonZero=629.145k
BM_SparseMatrixCompression_Eigen<SReal>/4096/150      46342 us        45833 us           15 nbNonZero=2.51658M
BM_SparseMatrixCompression_CRS<SReal>/512/10            131 us          131 us         5600 nbNonZero=2.621k
BM_SparseMatrixCompression_CRS<SReal>/1024/10           659 us          656 us         1120 nbNonZero=10.485k
BM_SparseMatrixCompression_CRS<SReal>/2048/10          2765 us         2761 us          249 nbNonZero=41.943k
BM_SparseMatrixCompression_CRS<SReal>/4096/10         11514 us        11719 us           64 nbNonZero=167.772k
BM_SparseMatrixCompression_CRS<SReal>/512/20            303 us          305 us         2358 nbNonZero=5.242k
BM_SparseMatrixCompression_CRS<SReal>/1024/20          1368 us         1367 us          560 nbNonZero=20.971k
BM_SparseMatrixCompression_CRS<SReal>/2048/20          5666 us         5580 us          112 nbNonZero=83.886k
BM_SparseMatrixCompression_CRS<SReal>/4096/20         23191 us        23438 us           32 nbNonZero=335.544k
BM_SparseMatrixCompression_CRS<SReal>/512/100          1694 us         1689 us          407 nbNonZero=26.214k
BM_SparseMatrixCompression_CRS<SReal>/1024/100         7171 us         7118 us           90 nbNonZero=104.857k
BM_SparseMatrixCompression_CRS<SReal>/2048/100        28234 us        28125 us           25 nbNonZero=419.43k
BM_SparseMatrixCompression_CRS<SReal>/4096/100       116725 us       117188 us            6 nbNonZero=1.67772M
BM_SparseMatrixCompression_CRS<SReal>/512/150          2534 us         2511 us          280 nbNonZero=39.321k
BM_SparseMatrixCompression_CRS<SReal>/1024/150        10821 us        10742 us           64 nbNonZero=157.286k
BM_SparseMatrixCompression_CRS<SReal>/2048/150        42435 us        42279 us           17 nbNonZero=629.145k
BM_SparseMatrixCompression_CRS<SReal>/4096/150       176862 us       175781 us            4 nbNonZero=2.51658M
```
## A^T * B

```
------------------------------------------------------------------------------------------------------------
Benchmark                                                  Time             CPU   Iterations UserCounters...
------------------------------------------------------------------------------------------------------------
BM_SparseMatrixMulTranspose_Eigen<SReal>/512/10          139 us          142 us         3733 nbNonZero=2.621k
BM_SparseMatrixMulTranspose_Eigen<SReal>/1024/10         337 us          338 us         2036 nbNonZero=10.485k
BM_SparseMatrixMulTranspose_Eigen<SReal>/2048/10         679 us          684 us         1120 nbNonZero=41.943k
BM_SparseMatrixMulTranspose_Eigen<SReal>/4096/10         695 us          698 us         1120 nbNonZero=167.772k
BM_SparseMatrixMulTranspose_Eigen<SReal>/512/20          195 us          195 us         3200 nbNonZero=5.242k
BM_SparseMatrixMulTranspose_Eigen<SReal>/1024/20         545 us          544 us         1120 nbNonZero=20.971k
BM_SparseMatrixMulTranspose_Eigen<SReal>/2048/20         655 us          656 us         1120 nbNonZero=83.886k
BM_SparseMatrixMulTranspose_Eigen<SReal>/4096/20         850 us          851 us         1120 nbNonZero=335.544k
BM_SparseMatrixMulTranspose_Eigen<SReal>/512/100         808 us          795 us          747 nbNonZero=26.214k
BM_SparseMatrixMulTranspose_Eigen<SReal>/1024/100        734 us          732 us          747 nbNonZero=104.857k
BM_SparseMatrixMulTranspose_Eigen<SReal>/2048/100        738 us          753 us         1120 nbNonZero=419.43k
BM_SparseMatrixMulTranspose_Eigen<SReal>/4096/100        814 us          820 us          896 nbNonZero=1.67772M
BM_SparseMatrixMulTranspose_Eigen<SReal>/512/150         759 us          767 us         1120 nbNonZero=39.321k
BM_SparseMatrixMulTranspose_Eigen<SReal>/1024/150        756 us          753 us         1120 nbNonZero=157.286k
BM_SparseMatrixMulTranspose_Eigen<SReal>/2048/150        744 us          739 us         1120 nbNonZero=629.145k
BM_SparseMatrixMulTranspose_Eigen<SReal>/4096/150        670 us          670 us          956 nbNonZero=2.51658M
BM_SparseMatrixMulTranspose_CRS<SReal>/512/10           2254 us         2247 us          299 nbNonZero=2.621k
BM_SparseMatrixMulTranspose_CRS<SReal>/1024/10         16143 us        15972 us           45 nbNonZero=10.485k
BM_SparseMatrixMulTranspose_CRS<SReal>/2048/10         35696 us        35938 us           20 nbNonZero=41.943k
BM_SparseMatrixMulTranspose_CRS<SReal>/4096/10         36201 us        36184 us           19 nbNonZero=167.772k
BM_SparseMatrixMulTranspose_CRS<SReal>/512/20           6833 us         6771 us           90 nbNonZero=5.242k
BM_SparseMatrixMulTranspose_CRS<SReal>/1024/20         29856 us        29830 us           22 nbNonZero=20.971k
BM_SparseMatrixMulTranspose_CRS<SReal>/2048/20         36193 us        36184 us           19 nbNonZero=83.886k
BM_SparseMatrixMulTranspose_CRS<SReal>/4096/20         35968 us        35156 us           20 nbNonZero=335.544k
BM_SparseMatrixMulTranspose_CRS<SReal>/512/100         32478 us        31960 us           22 nbNonZero=26.214k
BM_SparseMatrixMulTranspose_CRS<SReal>/1024/100        36296 us        36184 us           19 nbNonZero=104.857k
BM_SparseMatrixMulTranspose_CRS<SReal>/2048/100        35929 us        35362 us           19 nbNonZero=419.43k
BM_SparseMatrixMulTranspose_CRS<SReal>/4096/100        35821 us        36184 us           19 nbNonZero=1.67772M
BM_SparseMatrixMulTranspose_CRS<SReal>/512/150         34444 us        34539 us           19 nbNonZero=39.321k
BM_SparseMatrixMulTranspose_CRS<SReal>/1024/150        35838 us        36184 us           19 nbNonZero=157.286k
BM_SparseMatrixMulTranspose_CRS<SReal>/2048/150        35875 us        35938 us           20 nbNonZero=629.145k
BM_SparseMatrixMulTranspose_CRS<SReal>/4096/150        35909 us        35362 us           19 nbNonZero=2.51658M
```

# Conclusion

Use Eigen