### PR TITLE
Benchmark scene with specific advanced timers as a custom counter

### DIFF
--- a/SofaBenchmarkScenes/src/SofaBenchmarkScenes/BenchScene.h
+++ b/SofaBenchmarkScenes/src/SofaBenchmarkScenes/BenchScene.h
@@ -10,6 +10,7 @@
 
 #include <SofaSimulationGraph/init.h>
 #include <SofaComponentAll/initSofaComponentAll.h>
+#include <sofa/helper/AdvancedTimer.h>
 
 #include <boost/intrusive_ptr.hpp>
 
@@ -42,7 +43,6 @@ void BM_Scene_bench_SimulationFactor(benchmark::State& state)
             {
                 simu->animate(root.get(), TScene::dt);
             }
-            state.PauseTiming();
 
             simu->unload(root);
         }
@@ -54,11 +54,88 @@ void BM_Scene_bench_SimulationFactor(benchmark::State& state)
     sofa::simulation::graph::cleanup();
 }
 
+inline auto convertInSeconds(sofa::helper::system::thread::ctime_t t)
+{
+    static auto timer_freqd = static_cast<SReal>(sofa::helper::system::thread::CTime::getTicksPerSec());
+    return static_cast<SReal>(t) / static_cast<SReal>(timer_freqd);
+};
+
+// Generic benchmark for a scene (timing whole animation), and adding custom counters for specific AdvancedTimer labels
+// TScene (template argument) needs to implement getRoot() and dt
+template<typename TScene>
+void BM_Scene_bench_AdvancedTimer(benchmark::State& state, const std::vector<const char*>& advancedTimerLabels)
+{
+    sofa::helper::logging::MessageDispatcher::clearHandlers() ;
+
+    sofa::helper::AdvancedTimer::setEnabled("Animate", true);
+    sofa::helper::AdvancedTimer::setInterval("Animate", 1);
+    sofa::helper::AdvancedTimer::setOutputType("Animate", "gui");
+
+    sofa::component::initSofaComponentAll();
+
+    sofa::simulation::Simulation* simu = new sofa::simulation::graph::DAGSimulation();
+    setSimulation(simu);
+
+    std::vector<sofa::helper::AdvancedTimer::IdStep> timerIds;
+    timerIds.reserve(advancedTimerLabels.size());
+    for (const auto& label : advancedTimerLabels)
+    {
+        timerIds.emplace_back(label);
+    }
+    std::vector<SReal> avgTimers(advancedTimerLabels.size());
+
+    for (auto _ : state)
+    {
+        state.PauseTiming();
+        // Not ideal but did not find a way to clone/duplicate a scene
+        sofa::simulation::Node::SPtr root = TScene::getRoot();
+        root->init(sofa::core::execparams::defaultInstance());
+
+        state.ResumeTiming();
+        for (auto j = 0; j < state.range(0); j++)
+        {
+            sofa::helper::AdvancedTimer::begin("Animate");
+            simu->animate(root.get(), TScene::dt);
+            sofa::helper::AdvancedTimer::end("Animate");
+
+            const auto records = sofa::helper::AdvancedTimer::getStepData("Animate", true);
+            for (unsigned int i = 0; i < advancedTimerLabels.size(); ++i)
+            {
+                const auto findIt = records.find(timerIds[i]);
+                if (findIt == records.end())
+                {
+                    state.SkipWithError(("Timer " + std::string(advancedTimerLabels[i]) + " not found in this simulation").c_str());
+                    break;
+                }
+                const auto& stepData = findIt->second;
+                const auto duration = convertInSeconds(stepData.ttotal / stepData.num);
+                avgTimers[i] += duration;
+            }
+        }
+
+        sofa::helper::AdvancedTimer::clearData("Animate");
+
+        simu->unload(root);
+    }
+
+    std::transform(avgTimers.begin(), avgTimers.end(), avgTimers.begin(), [&state](SReal t) { return t / state.range(0);});
+    for (unsigned int i = 0; i < advancedTimerLabels.size(); ++i)
+    {
+        state.counters[advancedTimerLabels[i]] = benchmark::Counter(avgTimers[i], benchmark::Counter::kAvgIterations);
+    }
+    state.counters["FPS"] = benchmark::Counter(state.range(0), benchmark::Counter::kIsIterationInvariantRate); // nbTimeSteps * nbIterations / totalDuration
+    state.counters["frame"] = benchmark::Counter(state.range(0), benchmark::Counter::kIsIterationInvariantRate | benchmark::Counter::kInvert);
+
+    sofa::simulation::graph::cleanup();
+}
+
 // Generic benchmark for a scene (timing whole animation) with a increasing number of steps at once
 // TScene (template argument) needs to implement getRoot() and dt
 template<typename TScene>
 void BM_Scene_bench_StepFactor(benchmark::State& state)
 {
+    sofa::helper::logging::MessageDispatcher::clearHandlers() ;
+
     sofa::component::initSofaComponentAll();
 
     sofa::simulation::Simulation* simu = new sofa::simulation::graph::DAGSimulation();
@@ -66,6 +143,8 @@ void BM_Scene_bench_StepFactor(benchmark::State& state)
 
     for (auto _ : state)
     {
+        state.PauseTiming();
+
         // Not ideal but did not find a way to clone/duplicate a scene
         sofa::simulation::Node::SPtr root = TScene::getRoot();
         root->init(sofa::core::execparams::defaultInstance());
@@ -75,7 +154,7 @@ void BM_Scene_bench_StepFactor(benchmark::State& state)
         {
             simu->animate(root.get(), TScene::dt);
         }
-        state.PauseTiming();
+
         simu->unload(root);
     }
 

--- a/SofaBenchmarkScenes/src/SofaBenchmarkScenes/linearsolver/SparseLDLSolver.cpp
+++ b/SofaBenchmarkScenes/src/SofaBenchmarkScenes/linearsolver/SparseLDLSolver.cpp
@@ -53,3 +53,11 @@ constexpr int64_t maxNbSteps = 2048;
 constexpr int64_t stepNbSteps = 2;
 
 BENCHMARK_TEMPLATE1(BM_Scene_bench_StepFactor, SparseLDLSolverScene)->RangeMultiplier(stepNbSteps)->Ranges({ {minNbSteps, maxNbSteps} })->Unit(benchmark::kMillisecond);
+
+
+void BM_SparseLDLSolver(benchmark::State& state)
+{
+    BM_Scene_bench_AdvancedTimer<SparseLDLSolverScene>(state, {"MBKBuild", "MBKSolve"});
+}
+
+BENCHMARK(BM_SparseLDLSolver)->Arg(50)->Unit(benchmark::kMillisecond)->Iterations(10);


### PR DESCRIPTION
Example:

```
----------------------------------------------------------------------------------------------
Benchmark                                    Time             CPU   Iterations UserCounters...
----------------------------------------------------------------------------------------------
BM_SparseLDLSolver/50/iterations:10        199 ms          203 ms           10 FPS=246.154/s MBKBuild=546.345u MBKSolve=3.24531m frame=4.0625ms

```