### PR TITLE
Add benchmarks on toVecN (conversion between sofa::type::Vec's )

### DIFF
--- a/src/benchmarks/Sofa.Type/Vec.cpp
+++ b/src/benchmarks/Sofa.Type/Vec.cpp
@@ -21,12 +21,18 @@ static void BM_Vec_InitMemset(benchmark::State& state);
 static void BM_Vec_CopySimpleEqual(benchmark::State& state);
 static void BM_Vec_CopySimpleLoop(benchmark::State& state);
 static void BM_Vec_CopyStdCopy(benchmark::State& state);
+template <typename Container>
+static void BM_Vec_ConvertToVecNoop(benchmark::State& state);
+template <typename Container>
+static void BM_Vec_ConvertToVecIdentical(benchmark::State& state);
+template <typename FromContainer, typename ToContainer>
+static void BM_Vec_ConvertToVecDifferent(benchmark::State& state);
 
 using stdarray3f = std::array<float, 3>;
 using sofatypefixedarray3f = sofa::type::fixed_array<float, 3>;
 
-constexpr int64_t minSubIterations = 8 << 4;
-constexpr int64_t maxSubIterations = 8 << 6;
+constexpr int64_t minSubIterations = 8 << 14;
+constexpr int64_t maxSubIterations = 8 << 16;
 
 BENCHMARK(BM_Vec_dot)->RangeMultiplier(2)->Ranges({ {minSubIterations, maxSubIterations} })->Unit(benchmark::kMicrosecond);
 BENCHMARK_TEMPLATE1(BM_Vec_stdinnerproduct, stdarray3f)->RangeMultiplier(2)->Ranges({ {minSubIterations, maxSubIterations} })->Unit(benchmark::kMicrosecond);
@@ -37,6 +43,21 @@ BENCHMARK(BM_Vec_InitMemset)->RangeMultiplier(2)->Ranges({ {minSubIterations, ma
 BENCHMARK(BM_Vec_CopyStdCopy)->RangeMultiplier(2)->Ranges({ {minSubIterations, maxSubIterations} })->Unit(benchmark::kMicrosecond);
 BENCHMARK(BM_Vec_CopySimpleLoop)->RangeMultiplier(2)->Ranges({ {minSubIterations, maxSubIterations} })->Unit(benchmark::kMicrosecond);
 BENCHMARK(BM_Vec_CopySimpleEqual)->RangeMultiplier(2)->Ranges({ {minSubIterations, maxSubIterations} })->Unit(benchmark::kMicrosecond);
+BENCHMARK_TEMPLATE1(BM_Vec_ConvertToVecNoop, sofa::type::Vec3f)->RangeMultiplier(2)->Ranges({ {minSubIterations, maxSubIterations} })->Unit(benchmark::kMicrosecond);
+BENCHMARK_TEMPLATE1(BM_Vec_ConvertToVecNoop, sofa::type::Vec3d)->RangeMultiplier(2)->Ranges({ {minSubIterations, maxSubIterations} })->Unit(benchmark::kMicrosecond);
+BENCHMARK_TEMPLATE1(BM_Vec_ConvertToVecNoop, sofa::type::Vec6f)->RangeMultiplier(2)->Ranges({ {minSubIterations, maxSubIterations} })->Unit(benchmark::kMicrosecond);
+BENCHMARK_TEMPLATE1(BM_Vec_ConvertToVecNoop, sofa::type::Vec6d)->RangeMultiplier(2)->Ranges({ {minSubIterations, maxSubIterations} })->Unit(benchmark::kMicrosecond);
+BENCHMARK_TEMPLATE1(BM_Vec_ConvertToVecIdentical, sofa::type::Vec3f)->RangeMultiplier(2)->Ranges({ {minSubIterations, maxSubIterations} })->Unit(benchmark::kMicrosecond);
+BENCHMARK_TEMPLATE1(BM_Vec_ConvertToVecIdentical, sofa::type::Vec3d)->RangeMultiplier(2)->Ranges({ {minSubIterations, maxSubIterations} })->Unit(benchmark::kMicrosecond);
+BENCHMARK_TEMPLATE1(BM_Vec_ConvertToVecIdentical, sofa::type::Vec6f)->RangeMultiplier(2)->Ranges({ {minSubIterations, maxSubIterations} })->Unit(benchmark::kMicrosecond);
+BENCHMARK_TEMPLATE1(BM_Vec_ConvertToVecIdentical, sofa::type::Vec6d)->RangeMultiplier(2)->Ranges({ {minSubIterations, maxSubIterations} })->Unit(benchmark::kMicrosecond);
+BENCHMARK_TEMPLATE1(BM_Vec_ConvertToVecIdentical, sofa::type::Vec3i)->RangeMultiplier(2)->Ranges({ {minSubIterations, maxSubIterations} })->Unit(benchmark::kMicrosecond);
+BENCHMARK_TEMPLATE2(BM_Vec_ConvertToVecDifferent, sofa::type::Vec3d, sofa::type::Vec3f)->RangeMultiplier(2)->Ranges({ {minSubIterations, maxSubIterations} })->Unit(benchmark::kMicrosecond);
+BENCHMARK_TEMPLATE2(BM_Vec_ConvertToVecDifferent, sofa::type::Vec3f, sofa::type::Vec3d)->RangeMultiplier(2)->Ranges({ {minSubIterations, maxSubIterations} })->Unit(benchmark::kMicrosecond);
+BENCHMARK_TEMPLATE2(BM_Vec_ConvertToVecDifferent, sofa::type::Vec3d, sofa::type::Vec6d)->RangeMultiplier(2)->Ranges({ {minSubIterations, maxSubIterations} })->Unit(benchmark::kMicrosecond);
+BENCHMARK_TEMPLATE2(BM_Vec_ConvertToVecDifferent, sofa::type::Vec3d, sofa::type::Vec6f)->RangeMultiplier(2)->Ranges({ {minSubIterations, maxSubIterations} })->Unit(benchmark::kMicrosecond);
+BENCHMARK_TEMPLATE2(BM_Vec_ConvertToVecDifferent, sofa::type::Vec3d, sofa::type::Vec3i)->RangeMultiplier(2)->Ranges({ {minSubIterations, maxSubIterations} })->Unit(benchmark::kMicrosecond);
+BENCHMARK_TEMPLATE2(BM_Vec_ConvertToVecDifferent, sofa::type::Vec3d, sofa::type::Vec6i)->RangeMultiplier(2)->Ranges({ {minSubIterations, maxSubIterations} })->Unit(benchmark::kMicrosecond);
 
 // test on dot() for sofa::type::Vec
 void BM_Vec_dot(benchmark::State& state)
@@ -209,5 +230,96 @@ void BM_Vec_CopySimpleEqual(benchmark::State& state)
     for (auto _ : state)
     {
         b = list;
+    }
+}
+
+template<typename VectorContainer, typename Container = VectorContainer::value_type >
+void emplace_from_values(VectorContainer& list, const typename Container::value_type* values, std::size_t i)
+{
+    constexpr auto ContainerSize = Container::static_size;
+    
+    // Build an index sequence 0, 1, ..., ContainerSize-1
+    [&]<std::size_t... Is>(std::index_sequence<Is...>) {
+        list.emplace_back(values[i * ContainerSize + Is]...);
+    }(std::make_index_sequence<ContainerSize>{});
+}
+
+template <typename Container>
+void BM_Vec_ConvertToVecNoop(benchmark::State& state)
+{
+    constexpr auto ContainerSize = Container::static_size;
+    constexpr auto totalsize = maxSubIterations * ContainerSize;
+    const auto& values = RandomValuePool<typename Container::value_type, totalsize>::get();
+
+    sofa::type::vector<Container> list;
+    list.reserve(state.range(0));
+
+    for (unsigned int i = 0; i < state.range(0); i++)
+    {
+        emplace_from_values(list, values.data(), ContainerSize);
+    }
+
+    for (auto _ : state)
+    {
+        typename Container::value_type sum{};
+        for (unsigned int i = 0; i < state.range(0); ++i)
+        {
+            sum += list[i][0];
+        }
+        benchmark::DoNotOptimize(sum);
+    }
+}
+
+template <typename Container>
+void BM_Vec_ConvertToVecIdentical(benchmark::State& state)
+{
+    constexpr auto ContainerSize = Container::static_size;
+    constexpr auto totalsize = maxSubIterations * ContainerSize;
+    const auto& values = RandomValuePool<typename Container::value_type, totalsize>::get();
+
+    sofa::type::vector<Container> list;
+    list.reserve(state.range(0));
+
+    for (unsigned int i = 0; i < state.range(0); i++)
+    {
+        emplace_from_values(list, values.data(), ContainerSize);
+    }
+
+    for (auto _ : state)
+    {
+        typename Container::value_type sum{};
+        for (unsigned int i = 0; i < state.range(0); ++i)
+        {
+            const auto v = sofa::type::toVecN<Container>(list[i]);
+            sum += v[0];
+        }
+        benchmark::DoNotOptimize(sum);
+    }
+}
+
+template <typename FromContainer, typename ToContainer>
+void BM_Vec_ConvertToVecDifferent(benchmark::State& state)
+{
+    constexpr auto FromContainerSize = FromContainer::static_size;
+    constexpr auto totalsize = maxSubIterations * FromContainerSize;
+    const auto& values = RandomValuePool<typename FromContainer::value_type, totalsize>::get();
+
+    sofa::type::vector<FromContainer> list;
+    list.reserve(state.range(0));
+
+    for (unsigned int i = 0; i < state.range(0); i++)
+    {
+        emplace_from_values(list, values.data(), FromContainerSize);
+    }
+
+    for (auto _ : state)
+    {
+        typename ToContainer::value_type sum{};
+        for (unsigned int i = 0; i < state.range(0); ++i)
+        {
+            const auto v = sofa::type::toVecN<ToContainer>(list[i]);
+            sum += v[0];
+        }
+        benchmark::DoNotOptimize(sum);
     }
 }


### PR DESCRIPTION
and increases iterations as well.
It was made especially to measure the impact of conversion between identical types

FYI:
```
BM_Vec_ConvertToVecNoop<sofa::type::Vec3f>/131072                              90.3 us         90.3 us         7700
BM_Vec_ConvertToVecNoop<sofa::type::Vec3f>/262144                               180 us          180 us         3899
BM_Vec_ConvertToVecNoop<sofa::type::Vec3f>/524288                               358 us          358 us         1955
BM_Vec_ConvertToVecNoop<sofa::type::Vec3d>/131072                              89.4 us         89.4 us         7813
BM_Vec_ConvertToVecNoop<sofa::type::Vec3d>/262144                               179 us          179 us         3912
BM_Vec_ConvertToVecNoop<sofa::type::Vec3d>/524288                               361 us          361 us         1951
BM_Vec_ConvertToVecNoop<sofa::type::Vec6f>/131072                              89.5 us         89.5 us         7644
BM_Vec_ConvertToVecNoop<sofa::type::Vec6f>/262144                               179 us          179 us         3907
BM_Vec_ConvertToVecNoop<sofa::type::Vec6f>/524288                               359 us          359 us         1954
BM_Vec_ConvertToVecNoop<sofa::type::Vec6d>/131072                              91.9 us         91.9 us         7719
BM_Vec_ConvertToVecNoop<sofa::type::Vec6d>/262144                               183 us          183 us         3915
BM_Vec_ConvertToVecNoop<sofa::type::Vec6d>/524288                               377 us          377 us         1848
BM_Vec_ConvertToVecIdentical<sofa::type::Vec3f>/131072                         90.3 us         90.3 us         7759
BM_Vec_ConvertToVecIdentical<sofa::type::Vec3f>/262144                          179 us          179 us         3891
BM_Vec_ConvertToVecIdentical<sofa::type::Vec3f>/524288                          359 us          359 us         1946
BM_Vec_ConvertToVecIdentical<sofa::type::Vec3d>/131072                         91.7 us         91.7 us         7618
BM_Vec_ConvertToVecIdentical<sofa::type::Vec3d>/262144                          180 us          180 us         3843
BM_Vec_ConvertToVecIdentical<sofa::type::Vec3d>/524288                          370 us          370 us         1892
BM_Vec_ConvertToVecIdentical<sofa::type::Vec6f>/131072                         90.0 us         90.0 us         7757
BM_Vec_ConvertToVecIdentical<sofa::type::Vec6f>/262144                          183 us          183 us         3838
BM_Vec_ConvertToVecIdentical<sofa::type::Vec6f>/524288                          365 us          365 us         1929
BM_Vec_ConvertToVecIdentical<sofa::type::Vec6d>/131072                         95.1 us         95.1 us         7429
BM_Vec_ConvertToVecIdentical<sofa::type::Vec6d>/262144                          186 us          186 us         3765
BM_Vec_ConvertToVecIdentical<sofa::type::Vec6d>/524288                          378 us          378 us         1849
BM_Vec_ConvertToVecIdentical<sofa::type::Vec3i>/131072                         19.1 us         19.1 us        36582
BM_Vec_ConvertToVecIdentical<sofa::type::Vec3i>/262144                         39.9 us         39.9 us        17557
BM_Vec_ConvertToVecIdentical<sofa::type::Vec3i>/524288                         79.8 us         79.8 us         8690
BM_Vec_ConvertToVecDifferent<sofa::type::Vec3d,sofa::type::Vec3f>/131072       85.3 us         85.3 us         8077
BM_Vec_ConvertToVecDifferent<sofa::type::Vec3d,sofa::type::Vec3f>/262144        171 us          171 us         4107
BM_Vec_ConvertToVecDifferent<sofa::type::Vec3d,sofa::type::Vec3f>/524288        342 us          342 us         2046
BM_Vec_ConvertToVecDifferent<sofa::type::Vec3f,sofa::type::Vec3d>/131072       85.2 us         85.2 us         8174
BM_Vec_ConvertToVecDifferent<sofa::type::Vec3f,sofa::type::Vec3d>/262144        170 us          170 us         4072
BM_Vec_ConvertToVecDifferent<sofa::type::Vec3f,sofa::type::Vec3d>/524288        343 us          343 us         2046
BM_Vec_ConvertToVecDifferent<sofa::type::Vec3d,sofa::type::Vec6d>/131072       92.4 us         92.4 us         7495
BM_Vec_ConvertToVecDifferent<sofa::type::Vec3d,sofa::type::Vec6d>/262144        192 us          192 us         3666
BM_Vec_ConvertToVecDifferent<sofa::type::Vec3d,sofa::type::Vec6d>/524288        383 us          383 us         1827
BM_Vec_ConvertToVecDifferent<sofa::type::Vec3d,sofa::type::Vec6f>/131072       85.8 us         85.8 us         8182
BM_Vec_ConvertToVecDifferent<sofa::type::Vec3d,sofa::type::Vec6f>/262144        173 us          173 us         4079
BM_Vec_ConvertToVecDifferent<sofa::type::Vec3d,sofa::type::Vec6f>/524288        348 us          348 us         2026
BM_Vec_ConvertToVecDifferent<sofa::type::Vec3d,sofa::type::Vec3i>/131072       26.6 us         26.6 us        26385
BM_Vec_ConvertToVecDifferent<sofa::type::Vec3d,sofa::type::Vec3i>/262144       53.4 us         53.4 us        12990
BM_Vec_ConvertToVecDifferent<sofa::type::Vec3d,sofa::type::Vec3i>/524288        108 us          108 us         6482
BM_Vec_ConvertToVecDifferent<sofa::type::Vec3d,sofa::type::Vec6i>/131072       26.6 us         26.6 us        26326
BM_Vec_ConvertToVecDifferent<sofa::type::Vec3d,sofa::type::Vec6i>/262144       53.6 us         53.6 us        12977
BM_Vec_ConvertToVecDifferent<sofa::type::Vec3d,sofa::type::Vec6i>/524288        107 us          107 us         6502
```

Bottom lines: 
- it is virtually costless to convert apparently